### PR TITLE
fix a link in custom-node-list.json

### DIFF
--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -103,7 +103,7 @@
         {
             "author": "Derfuu",
             "title": "Derfuu_ComfyUI_ModdedNodes",
-            "reference": "hhttps://github.com/Derfuu/Derfuu_ComfyUI_ModdedNodes",
+            "reference": "https://github.com/Derfuu/Derfuu_ComfyUI_ModdedNodes",
             "files": [
                 "https://github.com/Derfuu/Derfuu_ComfyUI_ModdedNodes"
             ],


### PR DESCRIPTION
fix a broken link by removing a 'h' in url.