### PR TITLE
Fix for incompatible operator error

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -51,7 +51,7 @@ startup_script_path = os.path.join(comfyui_manager_path, "startup-scripts")
 
 
 def try_install_script(url, repo_path, install_cmd):
-    if platform.system() == "Windows" and comfy_ui_revision >= 1152:
+    if platform.system() == "Windows" and (not comfy_ui_revision.isdigit() or int(comfy_ui_revision) >= 1152):
         if not os.path.exists(startup_script_path):
             os.makedirs(startup_script_path)
 


### PR DESCRIPTION
When attempting to install a new custom node, I received the following error:

> Install(git-clone) error: {git url} / '>=' not supported between instances of 'str' and 'int'

This fixed it for me