### PR TITLE
Change Clybius/ComfyUI-Latent-Modifiers's "install_type"

### DIFF
--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -2047,7 +2047,7 @@
             "files": [
                 "https://github.com/Clybius/ComfyUI-Latent-Modifiers/raw/main/sampler_mega_modifier.py"
             ],
-            "install_type": "copy",
+            "install_type": "git-clone",
             "description": "Nodes: Latent Diffusion Mega Modifier. ComfyUI nodes which modify the latent during the diffusion process. (Sharpness, Tonemap, Rescale, Extra Noise)"
         },
         {


### PR DESCRIPTION
The repo needs to be cloned
Changes `Clybius/ComfyUI-Latent-Modifiers`'s `install_type` from `copy` to `git-clone`