### PR TITLE
Fix a typo in the name of my nodes!

### DIFF
--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -1954,7 +1954,7 @@
         },
         {
             "author": "chrisgoringe",
-            "title": "Use Everwhere",
+            "title": "Use Everywhere (UE Nodes)",
             "reference": "https://github.com/chrisgoringe/cg-use-everywhere",
             "files": [
                 "https://github.com/chrisgoringe/cg-use-everywhere"

--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -2053,6 +2053,16 @@
             ],
             "install_type": "git-clone",
             "description": "A custom node that pauses the flow while you choose which image (or latent) to pass on to the rest of the workflow."
+        },
+        {
+            "author": "chrisgoringe",
+            "title": "Use Everwhere",
+            "reference": "https://github.com/chrisgoringe/cg-use-everywhere",
+            "files": [
+                "https://github.com/chrisgoringe/cg-use-everwhere",
+            ],
+            "install_type": "git-clone",
+            "description": "A set of nodes that allow data to be 'broadcast' to some or all unconnected inputs. Greatly reduces link spaghetti."
         }
     ]
 }


### PR DESCRIPTION
Everywhere has a 'y' (and add 'UE nodes' to the name as well because that's what they seem to get called)