### PR TITLE
CUSTOM_NODE_LIST update bsz-cui-extras description

### DIFF
--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -1725,7 +1725,7 @@
                 "https://github.com/Beinsezii/bsz-cui-extras"
             ],
             "install_type": "git-clone",
-            "description": "This extension consists of auxiliary nodes for automatic calculation of latent sizes, an all-in-one node for SDXL's t2i, i2i, and scaling/hiresfix, and nodes capable of loading the Pixelbuster library.<p style='background-color: black; color: red;'>NOTE:Currently, the Pixelbuster library includes libraries for Windows and Linux environments by default. For other environments such as OSX, you will need to build and use Pixelbuster directly from <a href='https://github.com/Beinsezii/pixelbuster' target='blank'>here</a>.</P>"
+            "description": "This contains all-in-one 'principled' nodes for T2I, I2I, refining, and scaling. Additionally it has many tools for directly manipulating the color of latents, high res fix math, and scripted image post-processing."
         },
         {
             "author": "youyegit",


### PR DESCRIPTION
It now has a MacOS dylib for pixelbuster included directly in tree and a bunch of new latent manipulation tools.