### PR TITLE
Improve labels and cursors

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ![menu](misc/menu.jpg)
 
 ## NOTICE
-* 🏆 John us for the [ComfyUI Workflow Contest](https://contest.openart.ai/), hosted by OpenArt AI (11.27.2023 - 12.15.2023). Our esteemed judge panel includes Scott E. Detweiler, Olivio Sarikas, MERJIC麦橘, among others. We're also thrilled to have the authors of ComfyUI Manager and AnimateDiff as our special guests!  
+* 🏆 Join us for the [ComfyUI Workflow Contest](https://contest.openart.ai/), hosted by OpenArt AI (11.27.2023 - 12.15.2023). Our esteemed judge panel includes Scott E. Detweiler, Olivio Sarikas, MERJIC麦橘, among others. We're also thrilled to have the authors of ComfyUI Manager and AnimateDiff as our special guests!  
 * If you wish to hide the "Share" button, click "Manager" and choose "Share: None" option.
 * You can see whole nodes info on [ComfyUI Nodes Info](https://ltdrdata.github.io/) page.
 * Versions prior to V0.22.2 will no longer detect missing nodes unless using a local database. Please update ComfyUI-Manager to the latest version.

--- a/js/comfyui-manager.js
+++ b/js/comfyui-manager.js
@@ -399,15 +399,18 @@ class ManagerMenuDialog extends ComfyDialog {
 		this.local_mode_checkbox = $el("input",{type:'checkbox', id:"use_local_db"},[])
 		const checkbox_text = $el("label",{for: "use_local_db"},[" Use local DB"])
 		checkbox_text.style.color = "var(--fg-color)";
+		checkbox_text.style.cursor = "pointer";
 		checkbox_text.style.marginRight = "10px";
 
 		this.update_check_checkbox = $el("input",{type:'checkbox', id:"skip_update_check"},[])
 		const uc_checkbox_text = $el("label",{for:"skip_update_check"},[" Skip update check"])
 		uc_checkbox_text.style.color = "var(--fg-color)";
+		uc_checkbox_text.style.cursor = "pointer";
 		this.update_check_checkbox.checked = true;
 
 		// preview method
 		let preview_combo = document.createElement("select");
+		preview_combo.style.cursor = "pointer";
 		preview_combo.appendChild($el('option', { value: 'auto', text: 'Preview method: Auto' }, []));
 		preview_combo.appendChild($el('option', { value: 'taesd', text: 'Preview method: TAESD (slow)' }, []));
 		preview_combo.appendChild($el('option', { value: 'latent2rgb', text: 'Preview method: Latent2RGB (fast)' }, []));
@@ -423,6 +426,7 @@ class ManagerMenuDialog extends ComfyDialog {
 
 		// nickname
 		let badge_combo = document.createElement("select");
+		badge_combo.style.cursor = "pointer";
 		badge_combo.appendChild($el('option', { value: 'none', text: 'Badge: None' }, []));
 		badge_combo.appendChild($el('option', { value: 'nick', text: 'Badge: Nickname' }, []));
 		badge_combo.appendChild($el('option', { value: 'nick_hide', text: 'Badge: Nickname (hide built-in)' }, []));
@@ -441,6 +445,7 @@ class ManagerMenuDialog extends ComfyDialog {
 
 		// channel
 		let channel_combo = document.createElement("select");
+		channel_combo.style.cursor = "pointer";
 		api.fetchApi('/manager/channel_url_list')
 			.then(response => response.json())
 			.then(async data => {
@@ -466,6 +471,7 @@ class ManagerMenuDialog extends ComfyDialog {
 
 		// share
 		let share_combo = document.createElement("select");
+		share_combo.style.cursor = "pointer";
 		const share_options = [
 			['none', 'None'],
 			['openart', 'OpenArt AI'],

--- a/js/comfyui-manager.js
+++ b/js/comfyui-manager.js
@@ -21,6 +21,7 @@ docStyle.innerHTML = `
 .cm-menu-column {
 	display: flex;
 	flex-direction: column;
+	flex: 1 1 auto;
 }
 
 .cm-title {

--- a/js/comfyui-manager.js
+++ b/js/comfyui-manager.js
@@ -397,12 +397,12 @@ class ManagerMenuDialog extends ComfyDialog {
 		let self = this;
 
 		this.local_mode_checkbox = $el("input",{type:'checkbox', id:"use_local_db"},[])
-		const checkbox_text = $el("label",{},[" Use local DB"])
+		const checkbox_text = $el("label",{for: "use_local_db"},[" Use local DB"])
 		checkbox_text.style.color = "var(--fg-color)";
 		checkbox_text.style.marginRight = "10px";
 
 		this.update_check_checkbox = $el("input",{type:'checkbox', id:"skip_update_check"},[])
-		const uc_checkbox_text = $el("label",{},[" Skip update check"])
+		const uc_checkbox_text = $el("label",{for:"skip_update_check"},[" Skip update check"])
 		uc_checkbox_text.style.color = "var(--fg-color)";
 		this.update_check_checkbox.checked = true;
 


### PR DESCRIPTION
For #204 

- Fixes a minor typo on the README notice ("john" should be "join")
- Adds "for" attributes to the labels so when clicked they check the related checkbox
- Adds the "pointer" cursor styles to elements that are clickable (labels and options)
- Expands the menu columns to fill the available space