### PR TITLE
Fix notice

### DIFF
--- a/js/comfyui-manager.js
+++ b/js/comfyui-manager.js
@@ -32,11 +32,11 @@ docStyle.innerHTML = `
 }
 
 .cm-notice-board {
-	width: 360px;
+	width: 320px;
 	height: 160px;
 	overflow: auto;
 	color: var(--input-text);
-	border: 1px solid #ccc;
+	border: 1px solid var(--descrip-text);
 	padding: 10px;
 	overflow-x: hidden;
 }


### PR DESCRIPTION
#205 added a regression.

<img width="1110" alt="SCR-20231201-qljr" src="https://github.com/ltdrdata/ComfyUI-Manager/assets/2036594/a853b868-6ec0-4270-969d-f8a2c06f00eb">

This fixes it and adjust the border color 

<img width="1109" alt="SCR-20231201-qncm" src="https://github.com/ltdrdata/ComfyUI-Manager/assets/2036594/e03b5b11-644f-4d7b-99e4-713e3f6a8472">

I'd like to help make it more flexible in general, even if the columns overflow it will still be usable.
