### PR TITLE
add  EasyCaptureNode to custom-node-list

### DIFF
--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -3309,6 +3309,16 @@
             ],
             "install_type": "unzip",
             "description": "This is a node to convert an image into a CMYK Halftone dot image."
+        },
+        {
+            "author": "zhuanqianfish",
+            "title": "EasyCaptureNode for ComfyUI",
+            "reference": "https://github.com/zhuanqianfish/ComfyUI-EasyNode",
+            "files": [
+                "https://github.com/zhuanqianfish/ComfyUI-EasyNode"
+            ],
+            "install_type": "git-clone",
+            "description": "Capture window content from other programs, easyway combined with LCM for real-time painting"
         }
     ]
 }


### PR DESCRIPTION
EasyCaptureNode allows you to capture any window, for later use in the ControlNet or in any other node.
