### PR TITLE
Update color comfyui-manager.js

### DIFF
--- a/js/comfyui-manager.js
+++ b/js/comfyui-manager.js
@@ -83,8 +83,8 @@ docStyle.innerHTML = `
 }
 
 .cm-warn-note {
-	background-color: #000000 !important;
-	color: #FF0000 !important;
+	background-color: #101010 !important;
+	color: #FF3800 !important;
 	font-size: 13px;
 	border-radius: 5px;
 	padding: 10px;
@@ -93,8 +93,8 @@ docStyle.innerHTML = `
 }
 
 .cm-info-note {
-	background-color: #000000 !important;
-	color: #FF0000 !important;
+	background-color: #101010 !important;
+	color: #FF3800 !important;
 	font-size: 13px;
 	border-radius: 5px;
 	padding: 10px;


### PR DESCRIPTION
The design does not use completely black colors #000000, there should be a bit of gray. Red text on black is hard to read. I adjusted the colors accordingly.
![color](https://github.com/ltdrdata/ComfyUI-Manager/assets/58225118/a45761ba-db08-498c-809c-0d803f8b1db7)
