### PR TITLE
Add LongAnimateDiff models to model-list.json

### DIFF
--- a/model-list.json
+++ b/model-list.json
@@ -1338,6 +1338,26 @@
       "url": "https://huggingface.co/guoyww/animatediff/resolve/main/v2_lora_ZoomOut.ckpt"
     },
     {
+      "name": "LongAnimatediff/lt_long_mm_32_frames.ckpt (ComfyUI-AnimateDiff-Evolved)",
+      "type": "animatediff",
+      "base": "SD1.x",
+      "save_path": "custom_nodes/ComfyUI-AnimateDiff-Evolved/models",
+      "description": "Pressing 'install' directly downloads the model from the Kosinkadink/ComfyUI-AnimateDiff-Evolved extension node. (Note: Requires ComfyUI-Manager V0.24 or above)",
+      "reference": "https://huggingface.co/Lightricks/LongAnimateDiff",
+      "filename": "lt_long_mm_32_frames.ckpt",
+      "url": "https://huggingface.co/Lightricks/LongAnimateDiff/resolve/main/lt_long_mm_32_frames.ckpt"
+    },
+    {
+      "name": "LongAnimatediff/lt_long_mm_16_64_frames.ckpt (ComfyUI-AnimateDiff-Evolved)",
+      "type": "animatediff",
+      "base": "SD1.x",
+      "save_path": "custom_nodes/ComfyUI-AnimateDiff-Evolved/models",
+      "description": "Pressing 'install' directly downloads the model from the Kosinkadink/ComfyUI-AnimateDiff-Evolved extension node. (Note: Requires ComfyUI-Manager V0.24 or above)",
+      "reference": "https://huggingface.co/Lightricks/LongAnimateDiff",
+      "filename": "lt_long_mm_16_64_frames.ckpt",
+      "url": "https://huggingface.co/Lightricks/LongAnimateDiff/resolve/main/lt_long_mm_16_64_frames.ckpt"
+    },
+    {
       "name": "ip-adapter_sd15.safetensors",
       "type": "IP-Adapter",
       "base": "SD1.5",


### PR DESCRIPTION
This PR introduces the LongAnimateDiff models, which have been trained to generate videos with a variable frame count, ranging from 16 to 64 frames. This is in contrast to the AnimateDiff Models, which are limited to generating videos of 16 frames