### PR TITLE
Update extension-node-map.json

### DIFF
--- a/extension-node-map.json
+++ b/extension-node-map.json
@@ -2790,7 +2790,7 @@
     ],
     "https://github.com/bmad4ever/comfyui_lists_cartesian_product": [
         [
-            "Lists Cartesian Product"
+            "AnyListCartesianProduct"
         ],
         {
             "title_aux": "Lists Cartesian Product"


### PR DESCRIPTION
Replace display name by node name, fixes prior commit not detecting new node when missing (my bad).