### PR TITLE
Check that VHS_VideoCombine preview exists

### DIFF
--- a/js/comfyui-share-common.js
+++ b/js/comfyui-share-common.js
@@ -87,7 +87,7 @@ export function getPotentialOutputsAndOutputNodes(nodes) {
 						const widgetValue = node.widgets[j].value;
 						const parsedURLVals = widgetValue.params;
 
-						if(!parsedURLVals.format.startsWith('image')) {
+						if(!parsedURLVals.format?.startsWith('image')) {
 							// video isn't supported format
 							continue;
 						}


### PR DESCRIPTION
When Video Combine nodes are first added, params is initially an empty dict and lacks a format. As a result, an error is raised and the context menu can not be opened until some preview exists.

This pull request simply adds a check that a format exists to be parsed.
See Kosinkadink/ComfyUI-VideoHelperSuite#93