### PR TITLE
add long animatediff v1.1 model for 64 frames video generation

### DIFF
--- a/model-list.json
+++ b/model-list.json
@@ -1429,6 +1429,16 @@
       "url": "https://huggingface.co/Lightricks/LongAnimateDiff/resolve/main/lt_long_mm_16_64_frames.ckpt"
     },
     {
+      "name": "LongAnimatediff/lt_long_mm_16_64_frames_v1.1.ckpt (ComfyUI-AnimateDiff-Evolved)",
+      "type": "animatediff",
+      "base": "SD1.x",
+      "save_path": "custom_nodes/ComfyUI-AnimateDiff-Evolved/models",
+      "description": "Pressing 'install' directly downloads the model from the Kosinkadink/ComfyUI-AnimateDiff-Evolved extension node. (Note: Requires ComfyUI-Manager V0.24 or above)",
+      "reference": "https://huggingface.co/Lightricks/LongAnimateDiff",
+      "filename": "lt_long_mm_16_64_frames_v1.1.ckpt",
+      "url": "https://huggingface.co/Lightricks/LongAnimateDiff/resolve/main/lt_long_mm_16_64_frames_v1.1.ckpt"
+    },
+    {
       "name": "ip-adapter_sd15.safetensors",
       "type": "IP-Adapter",
       "base": "SD1.5",


### PR DESCRIPTION
This pr adds LongAnimateDiff v1.1 model into comfy, an improved version of LongAnimateDiff for up to 64 frames