### PR TITLE
Add Comfyui-styles-all to custom node list

### DIFF
--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -4803,6 +4803,16 @@
             ],
             "install_type": "unzip",
             "description": "This is a node to convert an image into a CMYK Halftone dot image."
-        }
+        },
+        {
+            "author": "Aegis72",
+            "title": "ComfyUI-styles-all",
+            "reference": "https://github.com/aegis72/comfyui-syles-all",
+            "files": [
+                "https://github.com/aegis72/comfyui-syles-all"
+            ],
+            "install_type": "git-clone",
+            "description": "This is a straight clone of Azazeal04's all-in-one styler menu, which was removed from gh on jan21, 2024. i have made no changes to the files at all."
+        }    
     ]
 }

--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -4484,9 +4484,6 @@
             "install_type": "git-clone",
             "description": "This exporter is a plugin for ComfyUI, which can export tasks for [a/LAizypainter](https://github.com/DimaChaichan/LAizypainter).\nLAizypainter is a Photoshop plugin with which you can send tasks directly to a Stable Diffusion server. More information about a [a/Task](https://github.com/DimaChaichan/LAizypainter?tab=readme-ov-file#task)"
         },
-
-
-
         {
             "author": "Ser-Hilary",
             "title": "SDXL_sizing",
@@ -4758,8 +4755,6 @@
             "install_type": "copy",
             "description": "A node which takes in x, y, width, height, total width, and total height, in order to accurately represent the area of an image which is covered by area-based conditioning."
         },
-
-
         {
             "author": "theally",
             "title": "TheAlly's Custom Nodes",
@@ -4813,6 +4808,6 @@
             ],
             "install_type": "git-clone",
             "description": "This is a straight clone of Azazeal04's all-in-one styler menu, which was removed from gh on Jan 21, 2024. I have made no changes to the files at all."
-        }    
+        }
     ]
 }

--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -4807,12 +4807,12 @@
         {
             "author": "Aegis72",
             "title": "ComfyUI-styles-all",
-            "reference": "https://github.com/aegis72/comfyui-syles-all",
+            "reference": "https://github.com/aegis72/comfyui-styles-all",
             "files": [
-                "https://github.com/aegis72/comfyui-syles-all"
+                "https://github.com/aegis72/comfyui-styles-all"
             ],
             "install_type": "git-clone",
-            "description": "This is a straight clone of Azazeal04's all-in-one styler menu, which was removed from gh on jan21, 2024. i have made no changes to the files at all."
+            "description": "This is a straight clone of Azazeal04's all-in-one styler menu, which was removed from gh on Jan 21, 2024. I have made no changes to the files at all."
         }    
     ]
 }


### PR DESCRIPTION
Yesterday, user Azazeal04 removed the comfyui-styles repo from GH, breaking my WFs and possibly the WFs of others. One other person forked the repo but made changes to it; this is a straight clone of the original files.