### PR TITLE
Update UltraSharp and AnimeSharp listings

### DIFF
--- a/model-list.json
+++ b/model-list.json
@@ -86,9 +86,9 @@
       "base": "upscale",
       "save_path": "default",
       "description": "4x-AnimeSharp upscaler model",
-      "reference": "https://huggingface.co/konohashinobi4/4xAnimesharp",
+      "reference": "https://huggingface.co/Kim2091/AnimeSharp/",
       "filename": "4x-AnimeSharp.pth",
-      "url": "https://huggingface.co/konohashinobi4/4xAnimesharp/resolve/main/4x-AnimeSharp.pth"
+      "url": "https://huggingface.co/Kim2091/AnimeSharp/resolve/main/4x-AnimeSharp.pth"
     },
     {
       "name": "4x-UltraSharp",
@@ -96,9 +96,9 @@
       "base": "upscale",
       "save_path": "default",
       "description": "4x-UltraSharp upscaler model",
-      "reference": "https://upscale.wiki/wiki/Model_Database",
+      "reference": "https://huggingface.co/Kim2091/UltraSharp/",
       "filename": "4x-UltraSharp.pth",
-      "url": "https://huggingface.co/datasets/Kizi-Art/Upscale/resolve/fa98e357882a23b8e7928957a39462fbfaee1af5/4x-UltraSharp.pth"
+      "url": "https://huggingface.co/Kim2091/UltraSharp/resolve/main/4x-UltraSharp.pth"
     },
     {
       "name": "4x_NMKD-Siax_200k",


### PR DESCRIPTION
They were attributed to HuggingFace repositories before that had the incorrect licenses and information assigned. I am the original author, see here: https://openmodeldb.info/users/kim2091