### PR TITLE
Instant Id model Add

### DIFF
--- a/model-list.json
+++ b/model-list.json
@@ -1818,7 +1818,7 @@
       "type": "insightface",
       "base": "inswapper",
       "save_path": "insightface/models/antelopev2",
-      "description": "Antelopev2 1k3d68.onnx model for InstantId.",
+      "description": "Antelopev2 1k3d68.onnx model for InstantId. (InstantId needs all Antelopev2 models)",
       "reference": "https://github.com/cubiq/ComfyUI_InstantID#installation",
       "filename": "1k3d68.onnx",
       "url": "https://huggingface.co/MonsterMMORPG/tools/resolve/main/1k3d68.onnx"
@@ -1828,7 +1828,7 @@
       "type": "insightface",
       "base": "inswapper",
       "save_path": "insightface/models/antelopev2",
-      "description": "Antelopev2 2d106det.onnx model for InstantId.",
+      "description": "Antelopev2 2d106det.onnx model for InstantId. (InstantId needs all Antelopev2 models)",
       "reference": "https://github.com/cubiq/ComfyUI_InstantID#installation",
       "filename": "2d106det.onnx",
       "url": "https://huggingface.co/MonsterMMORPG/tools/resolve/main/2d106det.onnx"
@@ -1838,7 +1838,7 @@
       "type": "insightface",
       "base": "inswapper",
       "save_path": "insightface/models/antelopev2",
-      "description": "Antelopev2 genderage.onnx model for InstantId.",
+      "description": "Antelopev2 genderage.onnx model for InstantId. (InstantId needs all Antelopev2 models)",
       "reference": "https://github.com/cubiq/ComfyUI_InstantID#installation",
       "filename": "genderage.onnx",
       "url": "https://huggingface.co/MonsterMMORPG/tools/resolve/main/genderage.onnx"
@@ -1848,7 +1848,7 @@
       "type": "insightface",
       "base": "inswapper",
       "save_path": "insightface/models/antelopev2",
-      "description": "Antelopev2 glintr100.onnx model for InstantId.",
+      "description": "Antelopev2 glintr100.onnx model for InstantId. (InstantId needs all Antelopev2 models)",
       "reference": "https://github.com/cubiq/ComfyUI_InstantID#installation",
       "filename": "glintr100.onnx",
       "url": "https://huggingface.co/MonsterMMORPG/tools/resolve/main/glintr100.onnx"
@@ -1858,7 +1858,7 @@
       "type": "insightface",
       "base": "inswapper",
       "save_path": "insightface/models/antelopev2",
-      "description": "Antelopev2 scrfd_10g_bnkps.onnx model for InstantId.",
+      "description": "Antelopev2 scrfd_10g_bnkps.onnx model for InstantId. (InstantId needs all Antelopev2 models)",
       "reference": "https://github.com/cubiq/ComfyUI_InstantID#installation",
       "filename": "scrfd_10g_bnkps.onnx",
       "url": "https://huggingface.co/MonsterMMORPG/tools/resolve/main/scrfd_10g_bnkps.onnx"

--- a/model-list.json
+++ b/model-list.json
@@ -1812,6 +1812,68 @@
       "reference": "https://huggingface.co/TencentARC/PhotoMaker",
       "filename": "photomaker-v1.bin",
       "url": "https://huggingface.co/TencentARC/PhotoMaker/resolve/main/photomaker-v1.bin"
+    },
+
+    {
+      "name": "1k3d68.onnx",
+      "type": "insightface",
+      "base": "inswapper",
+      "save_path": "insightface/models/antelopev2",
+      "description": "Antelopev2 1k3d68.onnx model for InstantId.",
+      "reference": "https://github.com/cubiq/ComfyUI_InstantID#installation",
+      "filename": "1k3d68.onnx",
+      "url": "https://huggingface.co/MonsterMMORPG/tools/resolve/main/1k3d68.onnx"
+    },
+    {
+      "name": "2d106det.onnx",
+      "type": "insightface",
+      "base": "inswapper",
+      "save_path": "insightface/models/antelopev2",
+      "description": "Antelopev2 2d106det.onnx model for InstantId.",
+      "reference": "https://github.com/cubiq/ComfyUI_InstantID#installation",
+      "filename": "2d106det.onnx",
+      "url": "https://huggingface.co/MonsterMMORPG/tools/resolve/main/2d106det.onnx"
+    },
+    {
+      "name": "genderage.onnx",
+      "type": "insightface",
+      "base": "inswapper",
+      "save_path": "insightface/models/antelopev2",
+      "description": "Antelopev2 genderage.onnx model for InstantId.",
+      "reference": "https://github.com/cubiq/ComfyUI_InstantID#installation",
+      "filename": "genderage.onnx",
+      "url": "https://huggingface.co/MonsterMMORPG/tools/resolve/main/genderage.onnx"
+    },
+    {
+      "name": "glintr100.onnx",
+      "type": "insightface",
+      "base": "inswapper",
+      "save_path": "insightface/models/antelopev2",
+      "description": "Antelopev2 glintr100.onnx model for InstantId.",
+      "reference": "https://github.com/cubiq/ComfyUI_InstantID#installation",
+      "filename": "glintr100.onnx",
+      "url": "https://huggingface.co/MonsterMMORPG/tools/resolve/main/glintr100.onnx"
+    },
+    {
+      "name": "scrfd_10g_bnkps.onnx",
+      "type": "insightface",
+      "base": "inswapper",
+      "save_path": "insightface/models/antelopev2",
+      "description": "Antelopev2 scrfd_10g_bnkps.onnx model for InstantId.",
+      "reference": "https://github.com/cubiq/ComfyUI_InstantID#installation",
+      "filename": "scrfd_10g_bnkps.onnx",
+      "url": "https://huggingface.co/MonsterMMORPG/tools/resolve/main/scrfd_10g_bnkps.onnx"
+    },
+
+    {
+      "name": "ip-adapter.bin",
+      "type": "instantid",
+      "base": "SDXL",
+      "save_path": "instantid",
+      "description": "InstantId main model based on IpAdapter",
+      "reference": "https://huggingface.co/InstantX/InstantID",
+      "filename": "ip-adapter.bin",
+      "url": "https://huggingface.co/InstantX/InstantID/resolve/main/ip-adapter.bin"
     }
   ]  
 }

--- a/model-list.json
+++ b/model-list.json
@@ -1813,7 +1813,6 @@
       "filename": "photomaker-v1.bin",
       "url": "https://huggingface.co/TencentARC/PhotoMaker/resolve/main/photomaker-v1.bin"
     },
-
     {
       "name": "1k3d68.onnx",
       "type": "insightface",

--- a/model-list.json
+++ b/model-list.json
@@ -1872,6 +1872,16 @@
       "reference": "https://huggingface.co/InstantX/InstantID",
       "filename": "ip-adapter.bin",
       "url": "https://huggingface.co/InstantX/InstantID/resolve/main/ip-adapter.bin"
+    },
+    {
+      "name": "diffusion_pytorch_model.safetensors",
+      "type": "controlnet",
+      "base": "SDXL",
+      "save_path": "controlnet/instantid",
+      "description": "InstantId controlnet model",
+      "reference": "https://huggingface.co/InstantX/InstantID",
+      "filename": "diffusion_pytorch_model.safetensors",
+      "url": "https://huggingface.co/InstantX/InstantID/resolve/main/ControlNetModel/diffusion_pytorch_model.safetensors"
     }
   ]  
 }

--- a/model-list.json
+++ b/model-list.json
@@ -1864,7 +1864,6 @@
       "filename": "scrfd_10g_bnkps.onnx",
       "url": "https://huggingface.co/MonsterMMORPG/tools/resolve/main/scrfd_10g_bnkps.onnx"
     },
-
     {
       "name": "ip-adapter.bin",
       "type": "instantid",


### PR DESCRIPTION
The native implementation of [InstantId](https://github.com/cubiq/ComfyUI_InstantID) has new models. This PR is to add those models into the `model-list.json` as described in the [install steps](https://github.com/cubiq/ComfyUI_InstantID#installation)