### PR TITLE
Add buffalo models for ipadapter plus

### DIFF
--- a/model-list.json
+++ b/model-list.json
@@ -2119,6 +2119,56 @@
       "reference": "https://huggingface.co/logtd/instance_diffusion",
       "filename": "scaleu.ckpt",
       "url": "https://huggingface.co/logtd/instance_diffusion/resolve/main/scaleu.ckpt"
+    },
+    {
+      "name": "1k3d68.onnx",
+      "type": "insightface",
+      "base": "inswapper",
+      "save_path": "insightface/models/buffalo_l",
+      "description": "Buffalo_l 1k3d68.onnx model for IpAdapterPlus",
+      "reference": "https://github.com/cubiq/ComfyUI_IPAdapter_plus?tab=readme-ov-file#faceid",
+      "filename": "1k3d68.onnx",
+      "url": "https://huggingface.co/public-data/insightface/resolve/main/models/buffalo_l/1k3d68.onnx"
+    },
+    {
+      "name": "2d106det.onnx",
+      "type": "insightface",
+      "base": "inswapper",
+      "save_path": "insightface/models/buffalo_l",
+      "description": "Buffalo_l 2d106det.onnx model for IpAdapterPlus",
+      "reference": "https://github.com/cubiq/ComfyUI_IPAdapter_plus?tab=readme-ov-file#faceid",
+      "filename": "2d106det.onnx",
+      "url": "https://huggingface.co/public-data/insightface/resolve/main/models/buffalo_l/2d106det.onnx"
+    },
+    {
+      "name": "det_10g.onnx",
+      "type": "insightface",
+      "base": "inswapper",
+      "save_path": "insightface/models/buffalo_l",
+      "description": "Buffalo_l det_10g.onnx model for IpAdapterPlus",
+      "reference": "https://github.com/cubiq/ComfyUI_IPAdapter_plus?tab=readme-ov-file#faceid",
+      "filename": "det_10g.onnx",
+      "url": "https://huggingface.co/public-data/insightface/resolve/main/models/buffalo_l/det_10g.onnx"
+    },
+    {
+      "name": "genderage.onnx",
+      "type": "insightface",
+      "base": "inswapper",
+      "save_path": "insightface/models/buffalo_l",
+      "description": "Buffalo_l genderage.onnx model for IpAdapterPlus",
+      "reference": "https://github.com/cubiq/ComfyUI_IPAdapter_plus?tab=readme-ov-file#faceid",
+      "filename": "genderage.onnx",
+      "url": "https://huggingface.co/public-data/insightface/resolve/main/models/buffalo_l/genderage.onnx"
+    },
+    {
+      "name": "w600k_r50.onnx",
+      "type": "insightface",
+      "base": "inswapper",
+      "save_path": "insightface/models/buffalo_l",
+      "description": "Buffalo_l w600k_r50.onnx model for IpAdapterPlus",
+      "reference": "https://github.com/cubiq/ComfyUI_IPAdapter_plus?tab=readme-ov-file#faceid",
+      "filename": "w600k_r50.onnx",
+      "url": "https://huggingface.co/public-data/insightface/resolve/main/models/buffalo_l/w600k_r50.onnx"
     }
   ]
 }


### PR DESCRIPTION
Adds the `buffalo_l` models for [IpAdapter_plus](https://github.com/cubiq/ComfyUI_IPAdapter_plus?tab=readme-ov-file#faceid) by cubiq

downloaded from [huggingface](https://huggingface.co/public-data/insightface/tree/main/models/buffalo_l)