### PR TITLE
Add ComfyUI-SaveAsScript Custom Node

### DIFF
--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -5768,6 +5768,16 @@
             "install_type": "git-clone",
             "description": "A simple node to round an input image up (pad) or down (crop) to the nearest integer multiple. Padding offset from left/bottom and the padding value are adjustable."
         },
+        {
+            "author": "atmaranto",
+            "title": "SaveAsScript",
+            "reference": "https://github.com/atmaranto/ComfyUI-SaveAsScript",
+            "files": [
+                "https://github.com/atmaranto/ComfyUI-SaveAsScript"
+            ],
+            "install_type": "git-clone",
+            "description": "A version of ComfyUI-to-Python-Extension that works as a custom node. Adds a button in the UI that saves the current workflow as a Python file, a CLI for converting workflows, and slightly better custom node support.",
+        }
         
         
         

--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -5777,7 +5777,7 @@
             ],
             "install_type": "git-clone",
             "description": "A version of ComfyUI-to-Python-Extension that works as a custom node. Adds a button in the UI that saves the current workflow as a Python file, a CLI for converting workflows, and slightly better custom node support.",
-        }
+        },
         
         
         

--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -5776,7 +5776,7 @@
                 "https://github.com/atmaranto/ComfyUI-SaveAsScript"
             ],
             "install_type": "git-clone",
-            "description": "A version of ComfyUI-to-Python-Extension that works as a custom node. Adds a button in the UI that saves the current workflow as a Python file, a CLI for converting workflows, and slightly better custom node support.",
+            "description": "A version of ComfyUI-to-Python-Extension that works as a custom node. Adds a button in the UI that saves the current workflow as a Python file, a CLI for converting workflows, and slightly better custom node support."
         },
         
         

--- a/extension-node-map.json
+++ b/extension-node-map.json
@@ -284,6 +284,15 @@
             "title_aux": "Jovimetrix Composition Nodes"
         }
     ],
+    "https://github.com/atmaranto/ComfyUI-SaveAsScript": [
+        [],
+        {
+            "author": "Anthony Maranto",
+            "description": "A version of ComfyUI-to-Python-Extension that works as a custom node. Adds a button in the UI that saves the current workflow as a Python file, a CLI for converting workflows, and slightly better custom node support.",
+            "nickname": "Save as Script",
+            "title": "SaveAsScript"
+        }
+    ],
     "https://github.com/ArtBot2023/CharacterFaceSwap": [
         [
             "Color Blend",

--- a/extension-node-map.json
+++ b/extension-node-map.json
@@ -284,15 +284,6 @@
             "title_aux": "Jovimetrix Composition Nodes"
         }
     ],
-    "https://github.com/atmaranto/ComfyUI-SaveAsScript": [
-        [],
-        {
-            "author": "Anthony Maranto",
-            "description": "A version of ComfyUI-to-Python-Extension that works as a custom node. Adds a button in the UI that saves the current workflow as a Python file, a CLI for converting workflows, and slightly better custom node support.",
-            "nickname": "Save as Script",
-            "title": "SaveAsScript"
-        }
-    ],
     "https://github.com/ArtBot2023/CharacterFaceSwap": [
         [
             "Color Blend",


### PR DESCRIPTION
I ported the [ComfyUI-to-Python-Extension](https://github.com/pydn/ComfyUI-to-Python-Extension) repository to [a custom node here](https://github.com/atmaranto/ComfyUI-SaveAsScript), which creates a button labeled "Save as Script" that simply converts the current workflow into a Python script and downloads it in the browser.

Tested an install/uninstall from the local db. Tested automatic installation of package requirements (`black`) when not present.

Let me know if any changes are necessary or if this doesn't really fit the project.