### PR TITLE
feat: add ComfyUI-J, Jannchie's diffusers based nodes

### DIFF
--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -6545,6 +6545,16 @@
             ],
             "install_type": "unzip",
             "description": "This is a node to convert an image into a CMYK Halftone dot image."
+        },
+        {
+            "author": "Jannchie",
+            "title": "ComfyUI-J",
+            "reference": "https://github.com/Jannchie/ComfyUI-J",
+            "files": [
+                "https://github.com/Jannchie/ComfyUI-J"
+            ],
+            "install_type": "git-clone",
+            "description": "This is a completely different set of nodes than Comfy's own KSampler series. This set of nodes is based on Diffusers, which makes it easier to import models, apply prompts with weights, inpaint, reference only, controlnet, etc."
         }
     ]
 }


### PR DESCRIPTION
This is a completely different set of nodes than Comfy's own KSampler series. This set of nodes is based on Diffusers, which makes it easier to import models, apply prompts with weights, inpaint, reference only, controlnet, etc.

![image](https://github.com/ltdrdata/ComfyUI-Manager/assets/29743310/05fc061d-8e94-4cf5-b668-f030ffb26710)
