### PR TITLE
Add GitHub stats for custom nodes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ startup-scripts/**
 matrix_auth
 channels.list
 comfyworkflows_sharekey
+github-stats-cache.json

--- a/github-stats.json
+++ b/github-stats.json
@@ -1,0 +1,2666 @@
+{
+    "https://github.com/ltdrdata/ComfyUI-Manager": {
+        "stars": 3189,
+        "last_update": "2024-04-01 15:43:47"
+    },
+    "https://github.com/ltdrdata/ComfyUI-Impact-Pack": {
+        "stars": 1065,
+        "last_update": "2024-04-02 05:15:17"
+    },
+    "https://github.com/ltdrdata/ComfyUI-Inspire-Pack": {
+        "stars": 200,
+        "last_update": "2024-03-24 08:10:22"
+    },
+    "https://github.com/comfyanonymous/ComfyUI_experiments": {
+        "stars": 119,
+        "last_update": "2023-09-13 06:28:20"
+    },
+    "https://github.com/Stability-AI/stability-ComfyUI-nodes": {
+        "stars": 159,
+        "last_update": "2023-08-18 19:03:06"
+    },
+    "https://github.com/Fannovel16/comfyui_controlnet_aux": {
+        "stars": 1117,
+        "last_update": "2024-04-01 18:25:56"
+    },
+    "https://github.com/Fannovel16/ComfyUI-Frame-Interpolation": {
+        "stars": 245,
+        "last_update": "2024-02-17 06:26:44"
+    },
+    "https://github.com/Fannovel16/ComfyUI-Loopchain": {
+        "stars": 24,
+        "last_update": "2023-12-15 14:25:35"
+    },
+    "https://github.com/Fannovel16/ComfyUI-MotionDiff": {
+        "stars": 117,
+        "last_update": "2024-04-01 16:39:58"
+    },
+    "https://github.com/Fannovel16/ComfyUI-Video-Matting": {
+        "stars": 107,
+        "last_update": "2024-02-12 13:57:45"
+    },
+    "https://github.com/BlenderNeko/ComfyUI_Cutoff": {
+        "stars": 286,
+        "last_update": "2024-03-16 09:59:53"
+    },
+    "https://github.com/BlenderNeko/ComfyUI_ADV_CLIP_emb": {
+        "stars": 217,
+        "last_update": "2024-03-13 08:17:35"
+    },
+    "https://github.com/BlenderNeko/ComfyUI_Noise": {
+        "stars": 171,
+        "last_update": "2023-12-25 16:37:59"
+    },
+    "https://github.com/BlenderNeko/ComfyUI_TiledKSampler": {
+        "stars": 238,
+        "last_update": "2024-03-14 02:39:35"
+    },
+    "https://github.com/BlenderNeko/ComfyUI_SeeCoder": {
+        "stars": 33,
+        "last_update": "2023-09-11 10:09:22"
+    },
+    "https://github.com/jags111/efficiency-nodes-comfyui": {
+        "stars": 471,
+        "last_update": "2024-03-25 13:41:14"
+    },
+    "https://github.com/jags111/ComfyUI_Jags_VectorMagic": {
+        "stars": 38,
+        "last_update": "2024-02-03 04:00:30"
+    },
+    "https://github.com/jags111/ComfyUI_Jags_Audiotools": {
+        "stars": 15,
+        "last_update": "2023-12-27 16:47:20"
+    },
+    "https://github.com/Derfuu/Derfuu_ComfyUI_ModdedNodes": {
+        "stars": 230,
+        "last_update": "2024-03-30 03:58:20"
+    },
+    "https://github.com/paulo-coronado/comfy_clip_blip_node": {
+        "stars": 25,
+        "last_update": "2023-09-27 00:33:21"
+    },
+    "https://github.com/Davemane42/ComfyUI_Dave_CustomNode": {
+        "stars": 246,
+        "last_update": "2024-04-02 00:59:02"
+    },
+    "https://github.com/WASasquatch/was-node-suite-comfyui": {
+        "stars": 755,
+        "last_update": "2024-03-20 00:46:04"
+    },
+    "https://github.com/WASasquatch/ComfyUI_Preset_Merger": {
+        "stars": 20,
+        "last_update": "2023-08-23 04:57:58"
+    },
+    "https://github.com/WASasquatch/PPF_Noise_ComfyUI": {
+        "stars": 19,
+        "last_update": "2023-10-01 03:36:57"
+    },
+    "https://github.com/WASasquatch/PowerNoiseSuite": {
+        "stars": 45,
+        "last_update": "2023-09-19 17:04:01"
+    },
+    "https://github.com/WASasquatch/FreeU_Advanced": {
+        "stars": 85,
+        "last_update": "2024-03-05 15:36:38"
+    },
+    "https://github.com/WASasquatch/ASTERR": {
+        "stars": 7,
+        "last_update": "2023-09-30 01:11:46"
+    },
+    "https://github.com/WASasquatch/WAS_Extras": {
+        "stars": 21,
+        "last_update": "2023-11-20 17:14:58"
+    },
+    "https://github.com/get-salt-AI/SaltAI": {
+        "stars": 35,
+        "last_update": "2024-03-19 15:37:49"
+    },
+    "https://github.com/omar92/ComfyUI-QualityOfLifeSuit_Omar92": {
+        "stars": 92,
+        "last_update": "2024-02-13 05:05:31"
+    },
+    "https://github.com/lilly1987/ComfyUI_node_Lilly": {
+        "stars": 49,
+        "last_update": "2023-11-24 20:13:20"
+    },
+    "https://github.com/sylym/comfy_vid2vid": {
+        "stars": 57,
+        "last_update": "2023-08-29 08:07:35"
+    },
+    "https://github.com/EllangoK/ComfyUI-post-processing-nodes": {
+        "stars": 133,
+        "last_update": "2024-02-07 01:59:01"
+    },
+    "https://github.com/LEv145/images-grid-comfy-plugin": {
+        "stars": 105,
+        "last_update": "2024-02-23 08:22:13"
+    },
+    "https://github.com/diontimmer/ComfyUI-Vextra-Nodes": {
+        "stars": 52,
+        "last_update": "2024-02-14 18:07:29"
+    },
+    "https://github.com/CYBERLOOM-INC/ComfyUI-nodes-hnmr": {
+        "stars": 2,
+        "last_update": "2024-01-01 20:01:25"
+    },
+    "https://github.com/BadCafeCode/masquerade-nodes-comfyui": {
+        "stars": 247,
+        "last_update": "2024-02-26 04:23:37"
+    },
+    "https://github.com/guoyk93/yk-node-suite-comfyui": {
+        "stars": 10,
+        "last_update": "2023-03-28 16:19:46"
+    },
+    "https://github.com/Jcd1230/rembg-comfyui-node": {
+        "stars": 94,
+        "last_update": "2023-04-03 00:12:22"
+    },
+    "https://github.com/YinBailiang/MergeBlockWeighted_fo_ComfyUI": {
+        "stars": 14,
+        "last_update": "2023-05-23 19:57:46"
+    },
+    "https://github.com/trojblue/trNodes": {
+        "stars": 8,
+        "last_update": "2024-03-17 00:16:43"
+    },
+    "https://github.com/szhublox/ambw_comfyui": {
+        "stars": 10,
+        "last_update": "2024-01-09 14:14:18"
+    },
+    "https://github.com/city96/ComfyUI_NetDist": {
+        "stars": 168,
+        "last_update": "2024-02-15 17:34:51"
+    },
+    "https://github.com/city96/SD-Latent-Interposer": {
+        "stars": 131,
+        "last_update": "2024-03-20 21:55:09"
+    },
+    "https://github.com/city96/SD-Advanced-Noise": {
+        "stars": 15,
+        "last_update": "2023-08-14 15:17:54"
+    },
+    "https://github.com/city96/SD-Latent-Upscaler": {
+        "stars": 96,
+        "last_update": "2023-11-27 00:26:14"
+    },
+    "https://github.com/city96/ComfyUI_DiT": {
+        "stars": 2,
+        "last_update": "2023-09-06 17:15:54"
+    },
+    "https://github.com/city96/ComfyUI_ColorMod": {
+        "stars": 13,
+        "last_update": "2023-09-30 15:24:38"
+    },
+    "https://github.com/city96/ComfyUI_ExtraModels": {
+        "stars": 80,
+        "last_update": "2024-03-16 17:20:28"
+    },
+    "https://github.com/Kaharos94/ComfyUI-Saveaswebp": {
+        "stars": 27,
+        "last_update": "2023-11-11 19:53:48"
+    },
+    "https://github.com/SLAPaper/ComfyUI-Image-Selector": {
+        "stars": 43,
+        "last_update": "2024-01-10 10:02:25"
+    },
+    "https://github.com/flyingshutter/As_ComfyUI_CustomNodes": {
+        "stars": 6,
+        "last_update": "2024-02-29 02:08:28"
+    },
+    "https://github.com/Zuellni/ComfyUI-Custom-Nodes": {
+        "stars": 43,
+        "last_update": "2023-09-19 12:11:26"
+    },
+    "https://github.com/Zuellni/ComfyUI-ExLlama": {
+        "stars": 77,
+        "last_update": "2024-02-26 12:24:06"
+    },
+    "https://github.com/Zuellni/ComfyUI-PickScore-Nodes": {
+        "stars": 14,
+        "last_update": "2024-02-09 16:03:17"
+    },
+    "https://github.com/AlekPet/ComfyUI_Custom_Nodes_AlekPet": {
+        "stars": 506,
+        "last_update": "2024-02-29 09:53:46"
+    },
+    "https://github.com/pythongosssss/ComfyUI-WD14-Tagger": {
+        "stars": 267,
+        "last_update": "2024-03-15 14:36:17"
+    },
+    "https://github.com/pythongosssss/ComfyUI-Custom-Scripts": {
+        "stars": 999,
+        "last_update": "2024-04-02 04:42:43"
+    },
+    "https://github.com/strimmlarn/ComfyUI_Strimmlarns_aesthetic_score": {
+        "stars": 20,
+        "last_update": "2024-03-01 23:00:05"
+    },
+    "https://github.com/TinyTerra/ComfyUI_tinyterraNodes": {
+        "stars": 231,
+        "last_update": "2024-03-10 07:42:00"
+    },
+    "https://github.com/Jordach/comfy-plasma": {
+        "stars": 39,
+        "last_update": "2023-07-31 00:57:50"
+    },
+    "https://github.com/bvhari/ComfyUI_ImageProcessing": {
+        "stars": 15,
+        "last_update": "2023-05-25 10:49:24"
+    },
+    "https://github.com/bvhari/ComfyUI_LatentToRGB": {
+        "stars": 10,
+        "last_update": "2023-05-20 06:50:37"
+    },
+    "https://github.com/bvhari/ComfyUI_PerpWeight": {
+        "stars": 8,
+        "last_update": "2024-03-25 07:05:23"
+    },
+    "https://github.com/ssitu/ComfyUI_UltimateSDUpscale": {
+        "stars": 485,
+        "last_update": "2024-03-30 17:18:43"
+    },
+    "https://github.com/ssitu/ComfyUI_restart_sampling": {
+        "stars": 49,
+        "last_update": "2024-04-02 04:43:43"
+    },
+    "https://github.com/ssitu/ComfyUI_roop": {
+        "stars": 56,
+        "last_update": "2023-09-05 16:18:48"
+    },
+    "https://github.com/ssitu/ComfyUI_fabric": {
+        "stars": 68,
+        "last_update": "2023-12-31 18:28:55"
+    },
+    "https://github.com/space-nuko/ComfyUI-Disco-Diffusion": {
+        "stars": 40,
+        "last_update": "2023-09-12 07:35:52"
+    },
+    "https://github.com/space-nuko/ComfyUI-OpenPose-Editor": {
+        "stars": 128,
+        "last_update": "2024-01-05 17:45:55"
+    },
+    "https://github.com/space-nuko/nui-suite": {
+        "stars": 10,
+        "last_update": "2023-06-04 22:08:46"
+    },
+    "https://github.com/Nourepide/ComfyUI-Allor": {
+        "stars": 140,
+        "last_update": "2024-03-21 07:40:20"
+    },
+    "https://github.com/melMass/comfy_mtb": {
+        "stars": 258,
+        "last_update": "2024-04-02 04:07:19"
+    },
+    "https://github.com/xXAdonesXx/NodeGPT": {
+        "stars": 299,
+        "last_update": "2024-02-01 23:20:08"
+    },
+    "https://github.com/Suzie1/ComfyUI_Comfyroll_CustomNodes": {
+        "stars": 357,
+        "last_update": "2024-03-22 16:13:20"
+    },
+    "https://github.com/bmad4ever/ComfyUI-Bmad-DirtyUndoRedo": {
+        "stars": 47,
+        "last_update": "2023-11-29 14:41:23"
+    },
+    "https://github.com/bmad4ever/comfyui_bmad_nodes": {
+        "stars": 36,
+        "last_update": "2024-04-02 03:51:18"
+    },
+    "https://github.com/bmad4ever/comfyui_ab_samplercustom": {
+        "stars": 3,
+        "last_update": "2023-11-06 17:45:57"
+    },
+    "https://github.com/bmad4ever/comfyui_lists_cartesian_product": {
+        "stars": 1,
+        "last_update": "2023-12-22 00:54:35"
+    },
+    "https://github.com/bmad4ever/comfyui_wfc_like": {
+        "stars": 2,
+        "last_update": "2024-03-19 23:02:45"
+    },
+    "https://github.com/bmad4ever/comfyui_quilting": {
+        "stars": 1,
+        "last_update": "2024-03-04 22:48:03"
+    },
+    "https://github.com/FizzleDorf/ComfyUI_FizzNodes": {
+        "stars": 249,
+        "last_update": "2024-03-24 14:52:58"
+    },
+    "https://github.com/FizzleDorf/ComfyUI-AIT": {
+        "stars": 42,
+        "last_update": "2023-11-08 14:03:03"
+    },
+    "https://github.com/filipemeneses/comfy_pixelization": {
+        "stars": 18,
+        "last_update": "2024-02-01 04:09:13"
+    },
+    "https://github.com/shiimizu/ComfyUI_smZNodes": {
+        "stars": 105,
+        "last_update": "2024-03-20 06:12:08"
+    },
+    "https://github.com/shiimizu/ComfyUI-TiledDiffusion": {
+        "stars": 120,
+        "last_update": "2024-02-19 10:44:28"
+    },
+    "https://github.com/ZaneA/ComfyUI-ImageReward": {
+        "stars": 22,
+        "last_update": "2024-02-04 23:38:10"
+    },
+    "https://github.com/SeargeDP/SeargeSDXL": {
+        "stars": 677,
+        "last_update": "2023-11-13 11:06:08"
+    },
+    "https://github.com/cubiq/ComfyUI_SimpleMath": {
+        "stars": 6,
+        "last_update": "2023-09-26 06:31:44"
+    },
+    "https://github.com/cubiq/ComfyUI_IPAdapter_plus": {
+        "stars": 1896,
+        "last_update": "2024-04-01 15:38:36"
+    },
+    "https://github.com/cubiq/ComfyUI_InstantID": {
+        "stars": 596,
+        "last_update": "2024-03-29 19:27:42"
+    },
+    "https://github.com/cubiq/ComfyUI_FaceAnalysis": {
+        "stars": 100,
+        "last_update": "2024-03-16 17:13:27"
+    },
+    "https://github.com/shockz0rz/ComfyUI_InterpolateEverything": {
+        "stars": 20,
+        "last_update": "2023-12-23 04:13:06"
+    },
+    "https://github.com/shockz0rz/comfy-easy-grids": {
+        "stars": 8,
+        "last_update": "2024-01-01 02:40:59"
+    },
+    "https://github.com/yolanother/DTAIComfyPromptAgent": {
+        "stars": 5,
+        "last_update": "2023-07-15 15:19:30"
+    },
+    "https://github.com/yolanother/DTAIImageToTextNode": {
+        "stars": 12,
+        "last_update": "2024-01-25 02:53:22"
+    },
+    "https://github.com/yolanother/DTAIComfyLoaders": {
+        "stars": 1,
+        "last_update": "2023-12-25 04:37:43"
+    },
+    "https://github.com/yolanother/DTAIComfyImageSubmit": {
+        "stars": 1,
+        "last_update": "2023-12-25 04:37:20"
+    },
+    "https://github.com/yolanother/DTAIComfyQRCodes": {
+        "stars": 2,
+        "last_update": "2023-12-25 04:38:00"
+    },
+    "https://github.com/yolanother/DTAIComfyVariables": {
+        "stars": 6,
+        "last_update": "2023-12-25 04:37:03"
+    },
+    "https://github.com/sipherxyz/comfyui-art-venture": {
+        "stars": 52,
+        "last_update": "2024-03-03 12:21:56"
+    },
+    "https://github.com/SOELexicon/ComfyUI-LexMSDBNodes": {
+        "stars": 4,
+        "last_update": "2023-07-21 11:22:18"
+    },
+    "https://github.com/pants007/comfy-pants": {
+        "stars": 2,
+        "last_update": "2023-08-13 12:02:23"
+    },
+    "https://github.com/evanspearman/ComfyMath": {
+        "stars": 35,
+        "last_update": "2023-08-27 03:29:04"
+    },
+    "https://github.com/civitai/comfy-nodes": {
+        "stars": 74,
+        "last_update": "2024-02-29 12:23:11"
+    },
+    "https://github.com/andersxa/comfyui-PromptAttention": {
+        "stars": 19,
+        "last_update": "2023-09-22 22:48:52"
+    },
+    "https://github.com/ArtVentureX/comfyui-animatediff": {
+        "stars": 576,
+        "last_update": "2024-01-06 09:18:52"
+    },
+    "https://github.com/twri/sdxl_prompt_styler": {
+        "stars": 495,
+        "last_update": "2024-03-24 18:55:24"
+    },
+    "https://github.com/wolfden/ComfyUi_PromptStylers": {
+        "stars": 49,
+        "last_update": "2023-10-22 21:34:59"
+    },
+    "https://github.com/wolfden/ComfyUi_String_Function_Tree": {
+        "stars": 7,
+        "last_update": "2023-10-22 22:12:55"
+    },
+    "https://github.com/daxthin/DZ-FaceDetailer": {
+        "stars": 83,
+        "last_update": "2023-12-16 17:31:44"
+    },
+    "https://github.com/asagi4/comfyui-prompt-control": {
+        "stars": 125,
+        "last_update": "2024-03-19 22:22:37"
+    },
+    "https://github.com/asagi4/ComfyUI-CADS": {
+        "stars": 23,
+        "last_update": "2024-03-25 00:35:48"
+    },
+    "https://github.com/asagi4/comfyui-utility-nodes": {
+        "stars": 6,
+        "last_update": "2024-03-10 16:04:01"
+    },
+    "https://github.com/jamesWalker55/comfyui-p2ldgan": {
+        "stars": 12,
+        "last_update": "2023-08-11 20:15:26"
+    },
+    "https://github.com/jamesWalker55/comfyui-various": {
+        "stars": 22,
+        "last_update": "2024-03-10 06:45:45"
+    },
+    "https://github.com/adieyal/comfyui-dynamicprompts": {
+        "stars": 145,
+        "last_update": "2024-02-05 06:55:50"
+    },
+    "https://github.com/mihaiiancu/ComfyUI_Inpaint": {
+        "stars": 9,
+        "last_update": "2023-07-30 22:32:41"
+    },
+    "https://github.com/kwaroran/abg-comfyui": {
+        "stars": 19,
+        "last_update": "2023-08-03 08:57:52"
+    },
+    "https://github.com/bash-j/mikey_nodes": {
+        "stars": 58,
+        "last_update": "2024-03-10 09:09:50"
+    },
+    "https://github.com/failfa-st/failfast-comfyui-extensions": {
+        "stars": 101,
+        "last_update": "2024-02-25 09:56:19"
+    },
+    "https://github.com/Pfaeff/pfaeff-comfyui": {
+        "stars": 17,
+        "last_update": "2023-08-19 19:28:36"
+    },
+    "https://github.com/wallish77/wlsh_nodes": {
+        "stars": 66,
+        "last_update": "2024-03-28 23:02:54"
+    },
+    "https://github.com/Kosinkadink/ComfyUI-Advanced-ControlNet": {
+        "stars": 298,
+        "last_update": "2024-04-01 23:20:36"
+    },
+    "https://github.com/Kosinkadink/ComfyUI-AnimateDiff-Evolved": {
+        "stars": 1868,
+        "last_update": "2024-03-29 11:22:34"
+    },
+    "https://github.com/Kosinkadink/ComfyUI-VideoHelperSuite": {
+        "stars": 271,
+        "last_update": "2024-03-31 00:31:24"
+    },
+    "https://github.com/Gourieff/comfyui-reactor-node": {
+        "stars": 792,
+        "last_update": "2024-03-28 06:06:36"
+    },
+    "https://github.com/imb101/ComfyUI-FaceSwap": {
+        "stars": 28,
+        "last_update": "2023-08-04 23:54:24"
+    },
+    "https://github.com/Chaoses-Ib/ComfyUI_Ib_CustomNodes": {
+        "stars": 7,
+        "last_update": "2024-02-29 15:21:23"
+    },
+    "https://github.com/AIrjen/OneButtonPrompt": {
+        "stars": 604,
+        "last_update": "2024-04-01 19:45:48"
+    },
+    "https://github.com/coreyryanhanson/ComfyQR": {
+        "stars": 35,
+        "last_update": "2024-03-20 20:10:27"
+    },
+    "https://github.com/coreyryanhanson/ComfyQR-scanning-nodes": {
+        "stars": 8,
+        "last_update": "2023-10-15 03:19:16"
+    },
+    "https://github.com/dimtoneff/ComfyUI-PixelArt-Detector": {
+        "stars": 135,
+        "last_update": "2024-01-07 03:29:57"
+    },
+    "https://github.com/hylarucoder/ComfyUI-Eagle-PNGInfo": {
+        "stars": 4,
+        "last_update": "2023-12-10 13:57:48"
+    },
+    "https://github.com/theUpsider/ComfyUI-Styles_CSV_Loader": {
+        "stars": 23,
+        "last_update": "2023-10-23 14:55:53"
+    },
+    "https://github.com/M1kep/Comfy_KepListStuff": {
+        "stars": 22,
+        "last_update": "2023-10-30 01:30:09"
+    },
+    "https://github.com/M1kep/ComfyLiterals": {
+        "stars": 8,
+        "last_update": "2023-11-20 01:08:21"
+    },
+    "https://github.com/M1kep/KepPromptLang": {
+        "stars": 4,
+        "last_update": "2023-11-19 08:27:04"
+    },
+    "https://github.com/M1kep/Comfy_KepMatteAnything": {
+        "stars": 9,
+        "last_update": "2023-09-27 01:16:51"
+    },
+    "https://github.com/M1kep/Comfy_KepKitchenSink": {
+        "stars": 0,
+        "last_update": "2023-09-25 05:58:26"
+    },
+    "https://github.com/M1kep/ComfyUI-OtherVAEs": {
+        "stars": 1,
+        "last_update": "2023-10-29 03:21:34"
+    },
+    "https://github.com/M1kep/ComfyUI-KepOpenAI": {
+        "stars": 20,
+        "last_update": "2023-11-08 22:43:37"
+    },
+    "https://github.com/uarefans/ComfyUI-Fans": {
+        "stars": 11,
+        "last_update": "2023-08-15 18:42:40"
+    },
+    "https://github.com/NicholasMcCarthy/ComfyUI_TravelSuite": {
+        "stars": 12,
+        "last_update": "2024-02-02 11:09:18"
+    },
+    "https://github.com/ManglerFTW/ComfyI2I": {
+        "stars": 128,
+        "last_update": "2023-11-03 11:09:53"
+    },
+    "https://github.com/theUpsider/ComfyUI-Logic": {
+        "stars": 69,
+        "last_update": "2023-12-12 20:29:49"
+    },
+    "https://github.com/mpiquero7164/ComfyUI-SaveImgPrompt": {
+        "stars": 12,
+        "last_update": "2023-08-14 11:27:09"
+    },
+    "https://github.com/m-sokes/ComfyUI-Sokes-Nodes": {
+        "stars": 1,
+        "last_update": "2023-08-16 11:33:14"
+    },
+    "https://github.com/Extraltodeus/noise_latent_perlinpinpin": {
+        "stars": 18,
+        "last_update": "2023-08-21 22:04:31"
+    },
+    "https://github.com/Extraltodeus/LoadLoraWithTags": {
+        "stars": 28,
+        "last_update": "2023-10-28 15:51:44"
+    },
+    "https://github.com/Extraltodeus/sigmas_tools_and_the_golden_scheduler": {
+        "stars": 26,
+        "last_update": "2024-01-25 16:30:20"
+    },
+    "https://github.com/Extraltodeus/ComfyUI-AutomaticCFG": {
+        "stars": 118,
+        "last_update": "2024-03-31 21:34:36"
+    },
+    "https://github.com/Extraltodeus/Vector_Sculptor_ComfyUI": {
+        "stars": 53,
+        "last_update": "2024-03-26 16:30:00"
+    },
+    "https://github.com/JPS-GER/ComfyUI_JPS-Nodes": {
+        "stars": 25,
+        "last_update": "2024-02-02 13:05:11"
+    },
+    "https://github.com/hustille/ComfyUI_hus_utils": {
+        "stars": 4,
+        "last_update": "2023-08-16 15:44:24"
+    },
+    "https://github.com/hustille/ComfyUI_Fooocus_KSampler": {
+        "stars": 53,
+        "last_update": "2023-09-10 01:51:24"
+    },
+    "https://github.com/badjeff/comfyui_lora_tag_loader": {
+        "stars": 35,
+        "last_update": "2024-02-12 07:46:02"
+    },
+    "https://github.com/rgthree/rgthree-comfy": {
+        "stars": 434,
+        "last_update": "2024-04-02 00:45:15"
+    },
+    "https://github.com/AIGODLIKE/AIGODLIKE-COMFYUI-TRANSLATION": {
+        "stars": 634,
+        "last_update": "2024-04-01 09:07:08"
+    },
+    "https://github.com/AIGODLIKE/AIGODLIKE-ComfyUI-Studio": {
+        "stars": 166,
+        "last_update": "2024-03-24 04:37:53"
+    },
+    "https://github.com/AIGODLIKE/ComfyUI-CUP": {
+        "stars": 0,
+        "last_update": "2024-03-22 07:26:43"
+    },
+    "https://github.com/syllebra/bilbox-comfyui": {
+        "stars": 64,
+        "last_update": "2024-02-13 18:49:16"
+    },
+    "https://github.com/giriss/comfy-image-saver": {
+        "stars": 104,
+        "last_update": "2023-11-16 10:39:05"
+    },
+    "https://github.com/shingo1228/ComfyUI-send-eagle-slim": {
+        "stars": 18,
+        "last_update": "2024-01-27 01:44:58"
+    },
+    "https://github.com/shingo1228/ComfyUI-SDXL-EmptyLatentImage": {
+        "stars": 20,
+        "last_update": "2023-08-17 07:51:02"
+    },
+    "https://github.com/laksjdjf/pfg-ComfyUI": {
+        "stars": 9,
+        "last_update": "2023-07-12 06:33:40"
+    },
+    "https://github.com/laksjdjf/attention-couple-ComfyUI": {
+        "stars": 52,
+        "last_update": "2024-03-25 03:38:55"
+    },
+    "https://github.com/laksjdjf/cd-tuner_negpip-ComfyUI": {
+        "stars": 16,
+        "last_update": "2023-11-23 02:06:20"
+    },
+    "https://github.com/laksjdjf/LCMSampler-ComfyUI": {
+        "stars": 14,
+        "last_update": "2023-11-08 11:07:04"
+    },
+    "https://github.com/laksjdjf/LoRTnoC-ComfyUI": {
+        "stars": 9,
+        "last_update": "2024-03-07 12:27:44"
+    },
+    "https://github.com/laksjdjf/Batch-Condition-ComfyUI": {
+        "stars": 1,
+        "last_update": "2024-03-09 12:22:07"
+    },
+    "https://github.com/alsritter/asymmetric-tiling-comfyui": {
+        "stars": 14,
+        "last_update": "2023-08-18 16:32:27"
+    },
+    "https://github.com/meap158/ComfyUI-GPU-temperature-protection": {
+        "stars": 3,
+        "last_update": "2023-10-07 09:45:25"
+    },
+    "https://github.com/meap158/ComfyUI-Prompt-Expansion": {
+        "stars": 54,
+        "last_update": "2023-09-17 00:00:31"
+    },
+    "https://github.com/meap158/ComfyUI-Background-Replacement": {
+        "stars": 23,
+        "last_update": "2023-12-17 14:05:08"
+    },
+    "https://github.com/TeaCrab/ComfyUI-TeaNodes": {
+        "stars": 4,
+        "last_update": "2024-02-07 21:57:28"
+    },
+    "https://github.com/nagolinc/ComfyUI_FastVAEDecorder_SDXL": {
+        "stars": 2,
+        "last_update": "2023-07-27 20:15:00"
+    },
+    "https://github.com/bradsec/ComfyUI_ResolutionSelector": {
+        "stars": 7,
+        "last_update": "2023-08-19 06:52:19"
+    },
+    "https://github.com/kohya-ss/ControlNet-LLLite-ComfyUI": {
+        "stars": 117,
+        "last_update": "2024-03-15 19:05:53"
+    },
+    "https://github.com/jjkramhoeft/ComfyUI-Jjk-Nodes": {
+        "stars": 4,
+        "last_update": "2023-08-19 19:17:07"
+    },
+    "https://github.com/dagthomas/comfyui_dagthomas": {
+        "stars": 40,
+        "last_update": "2024-01-03 09:59:57"
+    },
+    "https://github.com/marhensa/sdxl-recommended-res-calc": {
+        "stars": 46,
+        "last_update": "2024-03-15 05:43:38"
+    },
+    "https://github.com/Nuked88/ComfyUI-N-Nodes": {
+        "stars": 136,
+        "last_update": "2024-03-16 11:27:55"
+    },
+    "https://github.com/Nuked88/ComfyUI-N-Sidebar": {
+        "stars": 248,
+        "last_update": "2024-03-31 20:26:53"
+    },
+    "https://github.com/richinsley/Comfy-LFO": {
+        "stars": 4,
+        "last_update": "2023-08-23 23:08:16"
+    },
+    "https://github.com/Beinsezii/bsz-cui-extras": {
+        "stars": 19,
+        "last_update": "2024-01-11 23:53:04"
+    },
+    "https://github.com/youyegit/tdxh_node_comfyui": {
+        "stars": 2,
+        "last_update": "2023-09-21 08:40:50"
+    },
+    "https://github.com/Sxela/ComfyWarp": {
+        "stars": 19,
+        "last_update": "2023-11-04 10:45:11"
+    },
+    "https://github.com/skfoo/ComfyUI-Coziness": {
+        "stars": 17,
+        "last_update": "2024-02-23 18:59:41"
+    },
+    "https://github.com/YOUR-WORST-TACO/ComfyUI-TacoNodes": {
+        "stars": 12,
+        "last_update": "2023-08-30 16:06:45"
+    },
+    "https://github.com/Lerc/canvas_tab": {
+        "stars": 111,
+        "last_update": "2024-01-25 22:09:37"
+    },
+    "https://github.com/Ttl/ComfyUi_NNLatentUpscale": {
+        "stars": 122,
+        "last_update": "2023-08-28 13:56:20"
+    },
+    "https://github.com/spro/comfyui-mirror": {
+        "stars": 3,
+        "last_update": "2023-08-28 02:37:52"
+    },
+    "https://github.com/Tropfchen/ComfyUI-Embedding_Picker": {
+        "stars": 19,
+        "last_update": "2024-01-06 14:15:12"
+    },
+    "https://github.com/Acly/comfyui-tooling-nodes": {
+        "stars": 158,
+        "last_update": "2024-03-04 08:52:39"
+    },
+    "https://github.com/Acly/comfyui-inpaint-nodes": {
+        "stars": 234,
+        "last_update": "2024-03-24 16:00:17"
+    },
+    "https://github.com/picturesonpictures/comfy_PoP": {
+        "stars": 9,
+        "last_update": "2024-02-01 03:04:42"
+    },
+    "https://github.com/alt-key-project/comfyui-dream-project": {
+        "stars": 60,
+        "last_update": "2023-12-21 19:36:51"
+    },
+    "https://github.com/alt-key-project/comfyui-dream-video-batches": {
+        "stars": 37,
+        "last_update": "2023-12-03 10:31:55"
+    },
+    "https://github.com/seanlynch/comfyui-optical-flow": {
+        "stars": 19,
+        "last_update": "2023-10-20 21:22:17"
+    },
+    "https://github.com/ealkanat/comfyui_easy_padding": {
+        "stars": 10,
+        "last_update": "2023-09-26 14:56:04"
+    },
+    "https://github.com/ArtBot2023/CharacterFaceSwap": {
+        "stars": 46,
+        "last_update": "2023-10-25 04:29:40"
+    },
+    "https://github.com/mav-rik/facerestore_cf": {
+        "stars": 117,
+        "last_update": "2024-03-19 21:36:31"
+    },
+    "https://github.com/braintacles/braintacles-comfyui-nodes": {
+        "stars": 1,
+        "last_update": "2023-09-06 12:12:32"
+    },
+    "https://github.com/hayden-fr/ComfyUI-Model-Manager": {
+        "stars": 15,
+        "last_update": "2024-03-06 01:43:49"
+    },
+    "https://github.com/hayden-fr/ComfyUI-Image-Browsing": {
+        "stars": 2,
+        "last_update": "2023-09-07 14:06:12"
+    },
+    "https://github.com/ali1234/comfyui-job-iterator": {
+        "stars": 39,
+        "last_update": "2023-09-10 23:42:15"
+    },
+    "https://github.com/jmkl/ComfyUI-ricing": {
+        "stars": 9,
+        "last_update": "2023-09-11 03:33:34"
+    },
+    "https://github.com/budihartono/comfyui_otonx_nodes": {
+        "stars": 1,
+        "last_update": "2023-11-08 14:26:20"
+    },
+    "https://github.com/ramyma/A8R8_ComfyUI_nodes": {
+        "stars": 4,
+        "last_update": "2023-09-13 02:56:53"
+    },
+    "https://github.com/spinagon/ComfyUI-seamless-tiling": {
+        "stars": 39,
+        "last_update": "2024-01-29 03:45:40"
+    },
+    "https://github.com/tusharbhutt/Endless-Nodes": {
+        "stars": 21,
+        "last_update": "2023-10-21 23:02:19"
+    },
+    "https://github.com/spacepxl/ComfyUI-HQ-Image-Save": {
+        "stars": 17,
+        "last_update": "2024-03-30 05:10:42"
+    },
+    "https://github.com/spacepxl/ComfyUI-Image-Filters": {
+        "stars": 38,
+        "last_update": "2024-03-15 06:09:56"
+    },
+    "https://github.com/spacepxl/ComfyUI-RAVE": {
+        "stars": 69,
+        "last_update": "2024-01-28 09:08:08"
+    },
+    "https://github.com/phineas-pta/comfyui-auto-nodes-layout": {
+        "stars": 13,
+        "last_update": "2023-09-21 14:49:12"
+    },
+    "https://github.com/receyuki/comfyui-prompt-reader-node": {
+        "stars": 137,
+        "last_update": "2024-03-21 16:07:20"
+    },
+    "https://github.com/rklaffehn/rk-comfy-nodes": {
+        "stars": 2,
+        "last_update": "2024-01-23 17:12:45"
+    },
+    "https://github.com/cubiq/ComfyUI_essentials": {
+        "stars": 154,
+        "last_update": "2024-03-30 19:23:33"
+    },
+    "https://github.com/Clybius/ComfyUI-Latent-Modifiers": {
+        "stars": 35,
+        "last_update": "2024-01-02 21:57:58"
+    },
+    "https://github.com/Clybius/ComfyUI-Extra-Samplers": {
+        "stars": 19,
+        "last_update": "2024-03-25 21:14:59"
+    },
+    "https://github.com/mcmonkeyprojects/sd-dynamic-thresholding": {
+        "stars": 979,
+        "last_update": "2024-03-21 09:27:41"
+    },
+    "https://github.com/Tropfchen/ComfyUI-yaResolutionSelector": {
+        "stars": 5,
+        "last_update": "2024-01-20 14:15:58"
+    },
+    "https://github.com/chrisgoringe/cg-noise": {
+        "stars": 20,
+        "last_update": "2024-02-02 23:38:25"
+    },
+    "https://github.com/chrisgoringe/cg-image-picker": {
+        "stars": 109,
+        "last_update": "2024-03-29 04:17:32"
+    },
+    "https://github.com/chrisgoringe/cg-use-everywhere": {
+        "stars": 242,
+        "last_update": "2024-03-29 04:12:08"
+    },
+    "https://github.com/chrisgoringe/cg-prompt-info": {
+        "stars": 22,
+        "last_update": "2023-10-20 05:21:26"
+    },
+    "https://github.com/TGu-97/ComfyUI-TGu-utils": {
+        "stars": 1,
+        "last_update": "2023-09-25 04:06:55"
+    },
+    "https://github.com/seanlynch/srl-nodes": {
+        "stars": 3,
+        "last_update": "2023-10-22 22:35:41"
+    },
+    "https://github.com/alpertunga-bile/prompt-generator-comfyui": {
+        "stars": 48,
+        "last_update": "2024-03-29 10:58:50"
+    },
+    "https://github.com/mlinmg/ComfyUI-LaMA-Preprocessor": {
+        "stars": 60,
+        "last_update": "2023-12-21 04:31:58"
+    },
+    "https://github.com/kijai/ComfyUI-KJNodes": {
+        "stars": 154,
+        "last_update": "2024-04-01 13:20:28"
+    },
+    "https://github.com/kijai/ComfyUI-CCSR": {
+        "stars": 94,
+        "last_update": "2024-03-18 10:10:20"
+    },
+    "https://github.com/kijai/ComfyUI-SVD": {
+        "stars": 149,
+        "last_update": "2023-11-25 10:16:57"
+    },
+    "https://github.com/kijai/ComfyUI-Marigold": {
+        "stars": 293,
+        "last_update": "2024-04-01 22:48:01"
+    },
+    "https://github.com/kijai/ComfyUI-Geowizard": {
+        "stars": 57,
+        "last_update": "2024-03-30 10:16:56"
+    },
+    "https://github.com/kijai/ComfyUI-depth-fm": {
+        "stars": 35,
+        "last_update": "2024-03-23 23:45:51"
+    },
+    "https://github.com/kijai/ComfyUI-DDColor": {
+        "stars": 51,
+        "last_update": "2024-01-18 08:05:17"
+    },
+    "https://github.com/kijai/ComfyUI-ADMotionDirector": {
+        "stars": 82,
+        "last_update": "2024-03-27 19:38:20"
+    },
+    "https://github.com/kijai/ComfyUI-moondream": {
+        "stars": 52,
+        "last_update": "2024-03-11 00:50:24"
+    },
+    "https://github.com/kijai/ComfyUI-SUPIR": {
+        "stars": 777,
+        "last_update": "2024-03-29 22:29:23"
+    },
+    "https://github.com/kijai/ComfyUI-DynamiCrafterWrapper": {
+        "stars": 152,
+        "last_update": "2024-03-26 13:31:13"
+    },
+    "https://github.com/hhhzzyang/Comfyui_Lama": {
+        "stars": 29,
+        "last_update": "2023-10-01 17:33:29"
+    },
+    "https://github.com/thedyze/save-image-extended-comfyui": {
+        "stars": 54,
+        "last_update": "2023-11-09 17:48:44"
+    },
+    "https://github.com/SOELexicon/ComfyUI-LexTools": {
+        "stars": 17,
+        "last_update": "2024-03-15 17:45:41"
+    },
+    "https://github.com/mikkel/ComfyUI-text-overlay": {
+        "stars": 22,
+        "last_update": "2023-10-05 03:05:03"
+    },
+    "https://github.com/avatechai/avatar-graph-comfyui": {
+        "stars": 181,
+        "last_update": "2024-02-06 08:56:30"
+    },
+    "https://github.com/TRI3D-LC/tri3d-comfyui-nodes": {
+        "stars": 7,
+        "last_update": "2024-03-19 12:03:30"
+    },
+    "https://github.com/storyicon/comfyui_segment_anything": {
+        "stars": 334,
+        "last_update": "2024-03-30 10:11:17"
+    },
+    "https://github.com/a1lazydog/ComfyUI-AudioScheduler": {
+        "stars": 56,
+        "last_update": "2024-04-01 05:46:51"
+    },
+    "https://github.com/whatbirdisthat/cyberdolphin": {
+        "stars": 14,
+        "last_update": "2023-11-11 23:35:44"
+    },
+    "https://github.com/chrish-slingshot/CrasHUtils": {
+        "stars": 11,
+        "last_update": "2023-11-02 23:00:35"
+    },
+    "https://github.com/spinagon/ComfyUI-seam-carving": {
+        "stars": 10,
+        "last_update": "2023-10-13 07:24:05"
+    },
+    "https://github.com/YMC-GitHub/ymc-node-suite-comfyui": {
+        "stars": 14,
+        "last_update": "2023-12-27 14:18:04"
+    },
+    "https://github.com/chibiace/ComfyUI-Chibi-Nodes": {
+        "stars": 19,
+        "last_update": "2023-12-30 07:50:05"
+    },
+    "https://github.com/DigitalIO/ComfyUI-stable-wildcards": {
+        "stars": 19,
+        "last_update": "2023-12-18 23:42:52"
+    },
+    "https://github.com/THtianhao/ComfyUI-Portrait-Maker": {
+        "stars": 146,
+        "last_update": "2024-03-07 06:45:14"
+    },
+    "https://github.com/THtianhao/ComfyUI-FaceChain": {
+        "stars": 61,
+        "last_update": "2024-01-15 07:18:31"
+    },
+    "https://github.com/zer0TF/cute-comfy": {
+        "stars": 27,
+        "last_update": "2024-01-04 04:20:46"
+    },
+    "https://github.com/chflame163/ComfyUI_MSSpeech_TTS": {
+        "stars": 12,
+        "last_update": "2024-02-20 01:27:38"
+    },
+    "https://github.com/chflame163/ComfyUI_WordCloud": {
+        "stars": 40,
+        "last_update": "2024-02-27 12:47:52"
+    },
+    "https://github.com/chflame163/ComfyUI_LayerStyle": {
+        "stars": 321,
+        "last_update": "2024-03-31 12:18:19"
+    },
+    "https://github.com/chflame163/ComfyUI_FaceSimilarity": {
+        "stars": 2,
+        "last_update": "2024-03-22 05:35:23"
+    },
+    "https://github.com/drustan-hawk/primitive-types": {
+        "stars": 5,
+        "last_update": "2023-10-20 16:33:23"
+    },
+    "https://github.com/shadowcz007/comfyui-mixlab-nodes": {
+        "stars": 609,
+        "last_update": "2024-03-30 15:46:38"
+    },
+    "https://github.com/shadowcz007/comfyui-ultralytics-yolo": {
+        "stars": 9,
+        "last_update": "2024-03-29 08:35:02"
+    },
+    "https://github.com/shadowcz007/comfyui-consistency-decoder": {
+        "stars": 1,
+        "last_update": "2024-02-02 01:46:54"
+    },
+    "https://github.com/shadowcz007/comfyui-Image-reward": {
+        "stars": 7,
+        "last_update": "2024-03-25 05:41:04"
+    },
+    "https://github.com/ostris/ostris_nodes_comfyui": {
+        "stars": 17,
+        "last_update": "2023-11-26 21:41:27"
+    },
+    "https://github.com/0xbitches/ComfyUI-LCM": {
+        "stars": 239,
+        "last_update": "2023-11-11 21:24:33"
+    },
+    "https://github.com/aszc-dev/ComfyUI-CoreMLSuite": {
+        "stars": 68,
+        "last_update": "2023-12-01 00:09:15"
+    },
+    "https://github.com/taabata/LCM_Inpaint-Outpaint_Comfy": {
+        "stars": 202,
+        "last_update": "2024-02-19 22:14:46"
+    },
+    "https://github.com/noxinias/ComfyUI_NoxinNodes": {
+        "stars": 4,
+        "last_update": "2023-11-01 00:11:28"
+    },
+    "https://github.com/GMapeSplat/ComfyUI_ezXY": {
+        "stars": 16,
+        "last_update": "2023-11-30 00:32:24"
+    },
+    "https://github.com/kinfolk0117/ComfyUI_SimpleTiles": {
+        "stars": 22,
+        "last_update": "2024-01-29 19:27:12"
+    },
+    "https://github.com/kinfolk0117/ComfyUI_GradientDeepShrink": {
+        "stars": 20,
+        "last_update": "2023-12-01 20:13:00"
+    },
+    "https://github.com/kinfolk0117/ComfyUI_Pilgram": {
+        "stars": 6,
+        "last_update": "2024-01-07 14:49:46"
+    },
+    "https://github.com/Fictiverse/ComfyUI_Fictiverse": {
+        "stars": 6,
+        "last_update": "2023-11-29 12:58:14"
+    },
+    "https://github.com/idrirap/ComfyUI-Lora-Auto-Trigger-Words": {
+        "stars": 35,
+        "last_update": "2024-03-14 22:26:17"
+    },
+    "https://github.com/aianimation55/ComfyUI-FatLabels": {
+        "stars": 4,
+        "last_update": "2023-10-31 14:25:23"
+    },
+    "https://github.com/noembryo/ComfyUI-noEmbryo": {
+        "stars": 11,
+        "last_update": "2024-03-22 17:52:32"
+    },
+    "https://github.com/mikkel/comfyui-mask-boundingbox": {
+        "stars": 20,
+        "last_update": "2024-03-07 08:11:06"
+    },
+    "https://github.com/ParmanBabra/ComfyUI-Malefish-Custom-Scripts": {
+        "stars": 0,
+        "last_update": "2023-11-03 04:16:28"
+    },
+    "https://github.com/matan1905/ComfyUI-Serving-Toolkit": {
+        "stars": 30,
+        "last_update": "2024-02-28 18:30:35"
+    },
+    "https://github.com/PCMonsterx/ComfyUI-CSV-Loader": {
+        "stars": 8,
+        "last_update": "2023-11-06 06:34:25"
+    },
+    "https://github.com/Trung0246/ComfyUI-0246": {
+        "stars": 82,
+        "last_update": "2024-03-10 08:42:04"
+    },
+    "https://github.com/fexli/fexli-util-node-comfyui": {
+        "stars": 3,
+        "last_update": "2024-02-20 09:14:55"
+    },
+    "https://github.com/AbyssYuan0/ComfyUI_BadgerTools": {
+        "stars": 5,
+        "last_update": "2024-03-16 07:39:28"
+    },
+    "https://github.com/palant/image-resize-comfyui": {
+        "stars": 39,
+        "last_update": "2024-01-18 20:59:55"
+    },
+    "https://github.com/palant/integrated-nodes-comfyui": {
+        "stars": 27,
+        "last_update": "2023-12-27 22:52:00"
+    },
+    "https://github.com/palant/extended-saveimage-comfyui": {
+        "stars": 8,
+        "last_update": "2024-03-27 14:08:21"
+    },
+    "https://github.com/whmc76/ComfyUI-Openpose-Editor-Plus": {
+        "stars": 12,
+        "last_update": "2024-01-06 18:32:07"
+    },
+    "https://github.com/martijnat/comfyui-previewlatent": {
+        "stars": 27,
+        "last_update": "2024-02-15 05:52:28"
+    },
+    "https://github.com/banodoco/steerable-motion": {
+        "stars": 400,
+        "last_update": "2024-03-30 12:10:00"
+    },
+    "https://github.com/gemell1/ComfyUI_GMIC": {
+        "stars": 5,
+        "last_update": "2024-03-25 13:14:16"
+    },
+    "https://github.com/LonicaMewinsky/ComfyUI-MakeFrame": {
+        "stars": 20,
+        "last_update": "2023-11-27 14:47:20"
+    },
+    "https://github.com/TheBarret/ZSuite": {
+        "stars": 6,
+        "last_update": "2023-12-06 12:47:18"
+    },
+    "https://github.com/romeobuilderotti/ComfyUI-PNG-Metadata": {
+        "stars": 1,
+        "last_update": "2024-01-04 17:52:44"
+    },
+    "https://github.com/ka-puna/comfyui-yanc": {
+        "stars": 5,
+        "last_update": "2023-12-10 21:29:12"
+    },
+    "https://github.com/Amorano/Jovimetrix": {
+        "stars": 93,
+        "last_update": "2024-03-31 04:36:03"
+    },
+    "https://github.com/Umikaze-job/select_folder_path_easy": {
+        "stars": 4,
+        "last_update": "2023-11-18 14:59:56"
+    },
+    "https://github.com/Niutonian/ComfyUi-NoodleWebcam": {
+        "stars": 25,
+        "last_update": "2023-11-20 11:25:01"
+    },
+    "https://github.com/Feidorian/feidorian-ComfyNodes": {
+        "stars": 5,
+        "last_update": "2024-01-03 09:01:58"
+    },
+    "https://github.com/wutipong/ComfyUI-TextUtils": {
+        "stars": 1,
+        "last_update": "2023-11-20 21:32:07"
+    },
+    "https://github.com/natto-maki/ComfyUI-NegiTools": {
+        "stars": 19,
+        "last_update": "2024-02-02 07:50:01"
+    },
+    "https://github.com/LonicaMewinsky/ComfyUI-RawSaver": {
+        "stars": 1,
+        "last_update": "2023-11-21 14:34:54"
+    },
+    "https://github.com/jojkaart/ComfyUI-sampler-lcm-alternative": {
+        "stars": 68,
+        "last_update": "2024-02-17 11:54:33"
+    },
+    "https://github.com/GTSuya-Studio/ComfyUI-Gtsuya-Nodes": {
+        "stars": 5,
+        "last_update": "2023-12-10 01:20:36"
+    },
+    "https://github.com/oyvindg/ComfyUI-TrollSuite": {
+        "stars": 0,
+        "last_update": "2023-11-21 01:46:07"
+    },
+    "https://github.com/drago87/ComfyUI_Dragos_Nodes": {
+        "stars": 3,
+        "last_update": "2023-11-24 19:04:31"
+    },
+    "https://github.com/ansonkao/comfyui-geometry": {
+        "stars": 6,
+        "last_update": "2023-11-30 02:45:49"
+    },
+    "https://github.com/bronkula/comfyui-fitsize": {
+        "stars": 25,
+        "last_update": "2023-12-03 12:32:49"
+    },
+    "https://github.com/toyxyz/ComfyUI_toyxyz_test_nodes": {
+        "stars": 383,
+        "last_update": "2024-03-31 15:10:51"
+    },
+    "https://github.com/thecooltechguy/ComfyUI-Stable-Video-Diffusion": {
+        "stars": 247,
+        "last_update": "2023-11-24 06:14:27"
+    },
+    "https://github.com/thecooltechguy/ComfyUI-ComfyRun": {
+        "stars": 71,
+        "last_update": "2023-12-27 18:16:34"
+    },
+    "https://github.com/thecooltechguy/ComfyUI-MagicAnimate": {
+        "stars": 179,
+        "last_update": "2024-01-09 19:24:47"
+    },
+    "https://github.com/thecooltechguy/ComfyUI-ComfyWorkflows": {
+        "stars": 22,
+        "last_update": "2024-03-11 09:48:04"
+    },
+    "https://github.com/Danand/ComfyUI-ComfyCouple": {
+        "stars": 14,
+        "last_update": "2023-11-22 22:48:31"
+    },
+    "https://github.com/42lux/ComfyUI-safety-checker": {
+        "stars": 12,
+        "last_update": "2024-03-15 18:39:38"
+    },
+    "https://github.com/sergekatzmann/ComfyUI_Nimbus-Pack": {
+        "stars": 1,
+        "last_update": "2023-12-03 14:27:21"
+    },
+    "https://github.com/komojini/ComfyUI_SDXL_DreamBooth_LoRA_CustomNodes": {
+        "stars": 2,
+        "last_update": "2023-12-15 23:36:59"
+    },
+    "https://github.com/komojini/komojini-comfyui-nodes": {
+        "stars": 53,
+        "last_update": "2024-02-10 14:58:22"
+    },
+    "https://github.com/ZHO-ZHO-ZHO/ComfyUI-APISR": {
+        "stars": 227,
+        "last_update": "2024-03-24 14:20:44"
+    },
+    "https://github.com/ZHO-ZHO-ZHO/ComfyUI-Text_Image-Composite": {
+        "stars": 51,
+        "last_update": "2023-12-22 08:22:45"
+    },
+    "https://github.com/ZHO-ZHO-ZHO/ComfyUI-Gemini": {
+        "stars": 298,
+        "last_update": "2024-01-15 12:19:46"
+    },
+    "https://github.com/ZHO-ZHO-ZHO/comfyui-portrait-master-zh-cn": {
+        "stars": 1310,
+        "last_update": "2023-12-23 07:08:46"
+    },
+    "https://github.com/ZHO-ZHO-ZHO/ComfyUI-Q-Align": {
+        "stars": 2,
+        "last_update": "2024-01-03 15:22:13"
+    },
+    "https://github.com/ZHO-ZHO-ZHO/ComfyUI-InstantID": {
+        "stars": 1035,
+        "last_update": "2024-03-23 06:33:03"
+    },
+    "https://github.com/ZHO-ZHO-ZHO/ComfyUI-PhotoMaker-ZHO": {
+        "stars": 695,
+        "last_update": "2024-01-25 13:13:33"
+    },
+    "https://github.com/ZHO-ZHO-ZHO/ComfyUI-Qwen-VL-API": {
+        "stars": 152,
+        "last_update": "2024-03-12 10:32:47"
+    },
+    "https://github.com/ZHO-ZHO-ZHO/ComfyUI-SVD-ZHO": {
+        "stars": 74,
+        "last_update": "2024-02-06 09:16:21"
+    },
+    "https://github.com/ZHO-ZHO-ZHO/ComfyUI-SegMoE": {
+        "stars": 67,
+        "last_update": "2024-02-04 20:03:35"
+    },
+    "https://github.com/ZHO-ZHO-ZHO/ComfyUI-YoloWorld-EfficientSAM": {
+        "stars": 279,
+        "last_update": "2024-02-24 08:36:24"
+    },
+    "https://github.com/ZHO-ZHO-ZHO/ComfyUI-PixArt-alpha-Diffusers": {
+        "stars": 24,
+        "last_update": "2024-04-02 02:55:59"
+    },
+    "https://github.com/ZHO-ZHO-ZHO/ComfyUI-BRIA_AI-RMBG": {
+        "stars": 389,
+        "last_update": "2024-02-07 13:22:16"
+    },
+    "https://github.com/ZHO-ZHO-ZHO/ComfyUI-DepthFM": {
+        "stars": 46,
+        "last_update": "2024-03-25 02:09:04"
+    },
+    "https://github.com/ZHO-ZHO-ZHO/ComfyUI-BiRefNet-ZHO": {
+        "stars": 40,
+        "last_update": "2024-04-01 13:35:54"
+    },
+    "https://github.com/kenjiqq/qq-nodes-comfyui": {
+        "stars": 16,
+        "last_update": "2024-02-23 01:57:06"
+    },
+    "https://github.com/80sVectorz/ComfyUI-Static-Primitives": {
+        "stars": 9,
+        "last_update": "2023-12-11 11:06:16"
+    },
+    "https://github.com/AbdullahAlfaraj/Comfy-Photoshop-SD": {
+        "stars": 131,
+        "last_update": "2023-12-12 12:23:04"
+    },
+    "https://github.com/zhuanqianfish/ComfyUI-EasyNode": {
+        "stars": 50,
+        "last_update": "2023-12-13 12:02:43"
+    },
+    "https://github.com/discopixel-studio/comfyui-discopixel": {
+        "stars": 6,
+        "last_update": "2023-11-30 02:45:49"
+    },
+    "https://github.com/zcfrank1st/Comfyui-Yolov8": {
+        "stars": 13,
+        "last_update": "2024-02-25 06:28:49"
+    },
+    "https://github.com/SoftMeng/ComfyUI_Mexx_Styler": {
+        "stars": 11,
+        "last_update": "2023-11-30 07:35:07"
+    },
+    "https://github.com/SoftMeng/ComfyUI_Mexx_Poster": {
+        "stars": 14,
+        "last_update": "2023-12-05 09:44:42"
+    },
+    "https://github.com/wmatson/easy-comfy-nodes": {
+        "stars": 9,
+        "last_update": "2024-03-18 22:00:23"
+    },
+    "https://github.com/DrJKL/ComfyUI-Anchors": {
+        "stars": 4,
+        "last_update": "2024-03-20 22:40:29"
+    },
+    "https://github.com/vanillacode314/SimpleWildcardsComfyUI": {
+        "stars": 3,
+        "last_update": "2023-12-04 08:53:32"
+    },
+    "https://github.com/WebDev9000/WebDev9000-Nodes": {
+        "stars": 1,
+        "last_update": "2023-12-01 02:23:18"
+    },
+    "https://github.com/Scholar01/ComfyUI-Keyframe": {
+        "stars": 6,
+        "last_update": "2024-02-01 16:57:40"
+    },
+    "https://github.com/Haoming02/comfyui-diffusion-cg": {
+        "stars": 35,
+        "last_update": "2024-03-22 19:10:11"
+    },
+    "https://github.com/Haoming02/comfyui-prompt-format": {
+        "stars": 26,
+        "last_update": "2023-12-11 13:44:03"
+    },
+    "https://github.com/Haoming02/comfyui-clear-screen": {
+        "stars": 1,
+        "last_update": "2023-12-12 08:16:28"
+    },
+    "https://github.com/Haoming02/comfyui-menu-anchor": {
+        "stars": 3,
+        "last_update": "2024-01-26 03:54:55"
+    },
+    "https://github.com/Haoming02/comfyui-tab-handler": {
+        "stars": 3,
+        "last_update": "2023-12-14 08:24:49"
+    },
+    "https://github.com/Haoming02/comfyui-floodgate": {
+        "stars": 21,
+        "last_update": "2024-01-31 09:08:14"
+    },
+    "https://github.com/bedovyy/ComfyUI_NAIDGenerator": {
+        "stars": 15,
+        "last_update": "2024-03-13 09:36:48"
+    },
+    "https://github.com/Off-Live/ComfyUI-off-suite": {
+        "stars": 0,
+        "last_update": "2024-03-22 06:35:18"
+    },
+    "https://github.com/ningxiaoxiao/comfyui-NDI": {
+        "stars": 29,
+        "last_update": "2024-03-07 02:08:05"
+    },
+    "https://github.com/subtleGradient/TinkerBot-tech-for-ComfyUI-Touchpad": {
+        "stars": 11,
+        "last_update": "2024-01-14 20:01:01"
+    },
+    "https://github.com/zcfrank1st/comfyui_visual_anagrams": {
+        "stars": 5,
+        "last_update": "2023-12-05 12:31:26"
+    },
+    "https://github.com/Electrofried/ComfyUI-OpenAINode": {
+        "stars": 15,
+        "last_update": "2023-12-05 21:34:23"
+    },
+    "https://github.com/AustinMroz/ComfyUI-SpliceTools": {
+        "stars": 1,
+        "last_update": "2024-02-09 23:16:25"
+    },
+    "https://github.com/11cafe/comfyui-workspace-manager": {
+        "stars": 566,
+        "last_update": "2024-04-01 13:18:16"
+    },
+    "https://github.com/knuknX/ComfyUI-Image-Tools": {
+        "stars": 1,
+        "last_update": "2024-01-01 03:30:49"
+    },
+    "https://github.com/jtrue/ComfyUI-JaRue": {
+        "stars": 6,
+        "last_update": "2023-12-25 17:55:50"
+    },
+    "https://github.com/filliptm/ComfyUI_Fill-Nodes": {
+        "stars": 9,
+        "last_update": "2024-03-12 01:27:59"
+    },
+    "https://github.com/zfkun/ComfyUI_zfkun": {
+        "stars": 10,
+        "last_update": "2024-01-21 06:21:35"
+    },
+    "https://github.com/zcfrank1st/Comfyui-Toolbox": {
+        "stars": 2,
+        "last_update": "2023-12-13 11:36:14"
+    },
+    "https://github.com/talesofai/comfyui-browser": {
+        "stars": 333,
+        "last_update": "2024-03-31 05:16:02"
+    },
+    "https://github.com/yolain/ComfyUI-Easy-Use": {
+        "stars": 284,
+        "last_update": "2024-04-02 05:23:16"
+    },
+    "https://github.com/bruefire/ComfyUI-SeqImageLoader": {
+        "stars": 24,
+        "last_update": "2024-03-31 20:06:10"
+    },
+    "https://github.com/modusCell/ComfyUI-dimension-node-modusCell": {
+        "stars": 0,
+        "last_update": "2023-12-13 21:01:18"
+    },
+    "https://github.com/aria1th/ComfyUI-LogicUtils": {
+        "stars": 12,
+        "last_update": "2023-12-24 09:07:07"
+    },
+    "https://github.com/MitoshiroPJ/comfyui_slothful_attention": {
+        "stars": 5,
+        "last_update": "2023-12-16 09:10:38"
+    },
+    "https://github.com/brianfitzgerald/style_aligned_comfy": {
+        "stars": 203,
+        "last_update": "2024-03-12 03:42:07"
+    },
+    "https://github.com/deroberon/demofusion-comfyui": {
+        "stars": 79,
+        "last_update": "2023-12-19 22:54:02"
+    },
+    "https://github.com/deroberon/StableZero123-comfyui": {
+        "stars": 114,
+        "last_update": "2024-01-15 10:38:27"
+    },
+    "https://github.com/glifxyz/ComfyUI-GlifNodes": {
+        "stars": 5,
+        "last_update": "2024-03-15 14:30:29"
+    },
+    "https://github.com/concarne000/ConCarneNode": {
+        "stars": 2,
+        "last_update": "2024-01-23 06:05:24"
+    },
+    "https://github.com/aegis72/aegisflow_utility_nodes": {
+        "stars": 17,
+        "last_update": "2024-03-06 14:04:56"
+    },
+    "https://github.com/aegis72/comfyui-styles-all": {
+        "stars": 20,
+        "last_update": "2024-03-21 02:58:24"
+    },
+    "https://github.com/glibsonoran/Plush-for-ComfyUI": {
+        "stars": 79,
+        "last_update": "2024-03-27 15:00:07"
+    },
+    "https://github.com/vienteck/ComfyUI-Chat-GPT-Integration": {
+        "stars": 21,
+        "last_update": "2024-02-24 21:32:58"
+    },
+    "https://github.com/MNeMoNiCuZ/ComfyUI-mnemic-nodes": {
+        "stars": 9,
+        "last_update": "2024-04-01 10:37:35"
+    },
+    "https://github.com/AI2lab/comfyUI-tool-2lab": {
+        "stars": 0,
+        "last_update": "2024-03-24 16:59:45"
+    },
+    "https://github.com/SpaceKendo/ComfyUI-svd_txt2vid": {
+        "stars": 4,
+        "last_update": "2023-12-15 21:07:36"
+    },
+    "https://github.com/NimaNzrii/comfyui-popup_preview": {
+        "stars": 24,
+        "last_update": "2024-01-07 12:21:43"
+    },
+    "https://github.com/NimaNzrii/comfyui-photoshop": {
+        "stars": 48,
+        "last_update": "2023-12-20 13:03:59"
+    },
+    "https://github.com/rui40000/RUI-Nodes": {
+        "stars": 11,
+        "last_update": "2023-12-15 07:37:43"
+    },
+    "https://github.com/dmarx/ComfyUI-Keyframed": {
+        "stars": 72,
+        "last_update": "2023-12-30 00:37:20"
+    },
+    "https://github.com/dmarx/ComfyUI-AudioReactive": {
+        "stars": 4,
+        "last_update": "2024-01-03 08:27:32"
+    },
+    "https://github.com/TripleHeadedMonkey/ComfyUI_MileHighStyler": {
+        "stars": 11,
+        "last_update": "2023-12-16 19:21:57"
+    },
+    "https://github.com/BennyKok/comfyui-deploy": {
+        "stars": 531,
+        "last_update": "2024-03-28 15:15:47"
+    },
+    "https://github.com/florestefano1975/comfyui-portrait-master": {
+        "stars": 647,
+        "last_update": "2024-03-04 11:08:24"
+    },
+    "https://github.com/florestefano1975/comfyui-prompt-composer": {
+        "stars": 182,
+        "last_update": "2024-03-08 11:46:57"
+    },
+    "https://github.com/mozman/ComfyUI_mozman_nodes": {
+        "stars": 0,
+        "last_update": "2023-12-18 06:07:50"
+    },
+    "https://github.com/rcsaquino/comfyui-custom-nodes": {
+        "stars": 1,
+        "last_update": "2023-12-18 17:18:21"
+    },
+    "https://github.com/rcfcu2000/zhihuige-nodes-comfyui": {
+        "stars": 0,
+        "last_update": "2024-01-11 08:41:17"
+    },
+    "https://github.com/IDGallagher/ComfyUI-IG-Nodes": {
+        "stars": 0,
+        "last_update": "2024-02-04 03:37:05"
+    },
+    "https://github.com/violet-chen/comfyui-psd2png": {
+        "stars": 4,
+        "last_update": "2024-01-18 05:00:49"
+    },
+    "https://github.com/lldacing/comfyui-easyapi-nodes": {
+        "stars": 16,
+        "last_update": "2024-03-26 08:41:20"
+    },
+    "https://github.com/CosmicLaca/ComfyUI_Primere_Nodes": {
+        "stars": 49,
+        "last_update": "2024-04-01 13:00:41"
+    },
+    "https://github.com/RenderRift/ComfyUI-RenderRiftNodes": {
+        "stars": 6,
+        "last_update": "2023-12-31 11:14:29"
+    },
+    "https://github.com/OpenArt-AI/ComfyUI-Assistant": {
+        "stars": 12,
+        "last_update": "2024-01-24 21:44:12"
+    },
+    "https://github.com/ttulttul/ComfyUI-Iterative-Mixer": {
+        "stars": 86,
+        "last_update": "2024-04-01 19:58:39"
+    },
+    "https://github.com/ttulttul/ComfyUI-Tensor-Operations": {
+        "stars": 2,
+        "last_update": "2024-02-07 21:22:45"
+    },
+    "https://github.com/jitcoder/lora-info": {
+        "stars": 19,
+        "last_update": "2024-01-28 15:09:51"
+    },
+    "https://github.com/ceruleandeep/ComfyUI-LLaVA-Captioner": {
+        "stars": 52,
+        "last_update": "2024-03-04 10:07:53"
+    },
+    "https://github.com/styler00dollar/ComfyUI-sudo-latent-upscale": {
+        "stars": 16,
+        "last_update": "2023-12-31 16:26:46"
+    },
+    "https://github.com/styler00dollar/ComfyUI-deepcache": {
+        "stars": 5,
+        "last_update": "2023-12-26 17:53:44"
+    },
+    "https://github.com/NotHarroweD/Harronode": {
+        "stars": 4,
+        "last_update": "2023-12-31 06:00:14"
+    },
+    "https://github.com/Limitex/ComfyUI-Calculation": {
+        "stars": 0,
+        "last_update": "2023-12-27 17:50:16"
+    },
+    "https://github.com/Limitex/ComfyUI-Diffusers": {
+        "stars": 86,
+        "last_update": "2024-03-08 11:07:01"
+    },
+    "https://github.com/edenartlab/eden_comfy_pipelines": {
+        "stars": 22,
+        "last_update": "2024-03-18 05:40:42"
+    },
+    "https://github.com/pkpkTech/ComfyUI-SaveAVIF": {
+        "stars": 1,
+        "last_update": "2023-12-27 01:33:08"
+    },
+    "https://github.com/pkpkTech/ComfyUI-ngrok": {
+        "stars": 0,
+        "last_update": "2024-01-23 18:52:25"
+    },
+    "https://github.com/pkpkTech/ComfyUI-TemporaryLoader": {
+        "stars": 1,
+        "last_update": "2024-02-10 20:52:21"
+    },
+    "https://github.com/pkpkTech/ComfyUI-SaveQueues": {
+        "stars": 1,
+        "last_update": "2024-02-17 14:26:26"
+    },
+    "https://github.com/crystian/ComfyUI-Crystools": {
+        "stars": 308,
+        "last_update": "2024-03-27 16:59:44"
+    },
+    "https://github.com/crystian/ComfyUI-Crystools-save": {
+        "stars": 21,
+        "last_update": "2024-01-28 14:37:54"
+    },
+    "https://github.com/Kangkang625/ComfyUI-paint-by-example": {
+        "stars": 11,
+        "last_update": "2024-01-29 02:37:38"
+    },
+    "https://github.com/54rt1n/ComfyUI-DareMerge": {
+        "stars": 22,
+        "last_update": "2024-01-29 23:23:01"
+    },
+    "https://github.com/an90ray/ComfyUI_RErouter_CustomNodes": {
+        "stars": 0,
+        "last_update": "2023-12-30 01:42:04"
+    },
+    "https://github.com/jesenzhang/ComfyUI_StreamDiffusion": {
+        "stars": 88,
+        "last_update": "2023-12-29 09:41:48"
+    },
+    "https://github.com/ai-liam/comfyui_liam_util": {
+        "stars": 1,
+        "last_update": "2023-12-29 04:44:00"
+    },
+    "https://github.com/Ryuukeisyou/comfyui_face_parsing": {
+        "stars": 24,
+        "last_update": "2024-02-17 11:00:34"
+    },
+    "https://github.com/tocubed/ComfyUI-AudioReactor": {
+        "stars": 5,
+        "last_update": "2024-01-02 07:51:03"
+    },
+    "https://github.com/ntc-ai/ComfyUI-DARE-LoRA-Merge": {
+        "stars": 16,
+        "last_update": "2024-01-05 03:38:18"
+    },
+    "https://github.com/wwwins/ComfyUI-Simple-Aspect-Ratio": {
+        "stars": 1,
+        "last_update": "2024-01-02 04:07:20"
+    },
+    "https://github.com/ownimage/ComfyUI-ownimage": {
+        "stars": 0,
+        "last_update": "2024-01-01 16:36:42"
+    },
+    "https://github.com/Millyarde/Pomfy": {
+        "stars": 7,
+        "last_update": "2024-01-13 08:01:42"
+    },
+    "https://github.com/Ryuukeisyou/comfyui_io_helpers": {
+        "stars": 0,
+        "last_update": "2024-03-04 13:20:38"
+    },
+    "https://github.com/flowtyone/ComfyUI-Flowty-LDSR": {
+        "stars": 133,
+        "last_update": "2024-03-24 19:03:45"
+    },
+    "https://github.com/flowtyone/ComfyUI-Flowty-TripoSR": {
+        "stars": 275,
+        "last_update": "2024-03-19 10:49:59"
+    },
+    "https://github.com/flowtyone/ComfyUI-Flowty-CRM": {
+        "stars": 90,
+        "last_update": "2024-03-18 11:59:57"
+    },
+    "https://github.com/massao000/ComfyUI_aspect_ratios": {
+        "stars": 3,
+        "last_update": "2024-01-05 09:36:52"
+    },
+    "https://github.com/siliconflow/onediff_comfy_nodes": {
+        "stars": 7,
+        "last_update": "2024-01-04 11:33:08"
+    },
+    "https://github.com/ZHO-ZHO-ZHO/ComfyUI-ArtGallery": {
+        "stars": 179,
+        "last_update": "2024-02-12 01:56:02"
+    },
+    "https://github.com/hinablue/ComfyUI_3dPoseEditor": {
+        "stars": 87,
+        "last_update": "2024-01-04 14:41:18"
+    },
+    "https://github.com/chaojie/ComfyUI-AniPortrait": {
+        "stars": 148,
+        "last_update": "2024-04-02 03:06:43"
+    },
+    "https://github.com/chaojie/ComfyUI-Img2Img-Turbo": {
+        "stars": 30,
+        "last_update": "2024-03-27 01:10:14"
+    },
+    "https://github.com/chaojie/ComfyUI-Champ": {
+        "stars": 13,
+        "last_update": "2024-04-02 02:46:02"
+    },
+    "https://github.com/chaojie/ComfyUI-Open-Sora": {
+        "stars": 65,
+        "last_update": "2024-03-26 05:54:18"
+    },
+    "https://github.com/chaojie/ComfyUI-Trajectory": {
+        "stars": 5,
+        "last_update": "2024-03-14 14:41:18"
+    },
+    "https://github.com/chaojie/ComfyUI-dust3r": {
+        "stars": 9,
+        "last_update": "2024-03-31 00:30:51"
+    },
+    "https://github.com/chaojie/ComfyUI-Gemma": {
+        "stars": 5,
+        "last_update": "2024-02-24 10:02:51"
+    },
+    "https://github.com/chaojie/ComfyUI-DynamiCrafter": {
+        "stars": 69,
+        "last_update": "2024-03-16 19:08:28"
+    },
+    "https://github.com/chaojie/ComfyUI-Panda3d": {
+        "stars": 9,
+        "last_update": "2024-03-05 06:37:32"
+    },
+    "https://github.com/chaojie/ComfyUI-Pymunk": {
+        "stars": 15,
+        "last_update": "2024-01-31 15:36:36"
+    },
+    "https://github.com/chaojie/ComfyUI-MotionCtrl": {
+        "stars": 114,
+        "last_update": "2024-01-08 14:18:40"
+    },
+    "https://github.com/chaojie/ComfyUI-Motion-Vector-Extractor": {
+        "stars": 0,
+        "last_update": "2024-01-20 16:51:06"
+    },
+    "https://github.com/chaojie/ComfyUI-MotionCtrl-SVD": {
+        "stars": 69,
+        "last_update": "2024-01-16 09:41:07"
+    },
+    "https://github.com/chaojie/ComfyUI-DragAnything": {
+        "stars": 53,
+        "last_update": "2024-03-19 03:37:48"
+    },
+    "https://github.com/chaojie/ComfyUI-DragNUWA": {
+        "stars": 325,
+        "last_update": "2024-03-14 06:56:41"
+    },
+    "https://github.com/chaojie/ComfyUI-Moore-AnimateAnyone": {
+        "stars": 191,
+        "last_update": "2024-02-24 13:48:57"
+    },
+    "https://github.com/chaojie/ComfyUI-I2VGEN-XL": {
+        "stars": 22,
+        "last_update": "2024-01-19 09:02:08"
+    },
+    "https://github.com/chaojie/ComfyUI-LightGlue": {
+        "stars": 48,
+        "last_update": "2024-01-20 16:53:51"
+    },
+    "https://github.com/chaojie/ComfyUI-RAFT": {
+        "stars": 24,
+        "last_update": "2024-01-29 08:08:13"
+    },
+    "https://github.com/alexopus/ComfyUI-Image-Saver": {
+        "stars": 13,
+        "last_update": "2024-04-01 20:42:20"
+    },
+    "https://github.com/kft334/Knodes": {
+        "stars": 0,
+        "last_update": "2024-01-14 04:23:09"
+    },
+    "https://github.com/MrForExample/ComfyUI-3D-Pack": {
+        "stars": 1257,
+        "last_update": "2024-04-01 13:51:02"
+    },
+    "https://github.com/MrForExample/ComfyUI-AnimateAnyone-Evolved": {
+        "stars": 371,
+        "last_update": "2024-02-02 14:19:37"
+    },
+    "https://github.com/Hangover3832/ComfyUI-Hangover-Nodes": {
+        "stars": 19,
+        "last_update": "2024-03-31 17:06:25"
+    },
+    "https://github.com/Hangover3832/ComfyUI-Hangover-Moondream": {
+        "stars": 19,
+        "last_update": "2024-03-31 17:08:35"
+    },
+    "https://github.com/Hangover3832/ComfyUI-Hangover-Recognize_Anything": {
+        "stars": 3,
+        "last_update": "2024-03-31 17:56:08"
+    },
+    "https://github.com/tzwm/comfyui-profiler": {
+        "stars": 27,
+        "last_update": "2024-01-12 07:38:40"
+    },
+    "https://github.com/daniel-lewis-ab/ComfyUI-Llama": {
+        "stars": 19,
+        "last_update": "2024-03-19 22:59:53"
+    },
+    "https://github.com/daniel-lewis-ab/ComfyUI-TTS": {
+        "stars": 3,
+        "last_update": "2024-01-28 00:07:17"
+    },
+    "https://github.com/djbielejeski/a-person-mask-generator": {
+        "stars": 178,
+        "last_update": "2024-02-16 16:26:02"
+    },
+    "https://github.com/smagnetize/kb-comfyui-nodes": {
+        "stars": 0,
+        "last_update": "2024-01-06 17:04:40"
+    },
+    "https://github.com/ginlov/segment_to_mask_comfyui": {
+        "stars": 1,
+        "last_update": "2024-01-07 14:03:21"
+    },
+    "https://github.com/glowcone/comfyui-base64-to-image": {
+        "stars": 5,
+        "last_update": "2024-01-09 08:33:02"
+    },
+    "https://github.com/AInseven/ComfyUI-fastblend": {
+        "stars": 74,
+        "last_update": "2024-02-26 16:17:27"
+    },
+    "https://github.com/HebelHuber/comfyui-enhanced-save-node": {
+        "stars": 0,
+        "last_update": "2024-01-12 14:34:55"
+    },
+    "https://github.com/LarryJane491/Lora-Training-in-Comfy": {
+        "stars": 163,
+        "last_update": "2024-03-03 17:16:51"
+    },
+    "https://github.com/LarryJane491/Image-Captioning-in-ComfyUI": {
+        "stars": 17,
+        "last_update": "2024-03-08 19:59:00"
+    },
+    "https://github.com/Layer-norm/comfyui-lama-remover": {
+        "stars": 29,
+        "last_update": "2024-01-13 04:58:58"
+    },
+    "https://github.com/Taremin/comfyui-prompt-extranetworks": {
+        "stars": 1,
+        "last_update": "2024-01-27 05:51:35"
+    },
+    "https://github.com/Taremin/comfyui-string-tools": {
+        "stars": 1,
+        "last_update": "2024-02-16 16:28:32"
+    },
+    "https://github.com/Taremin/webui-monaco-prompt": {
+        "stars": 23,
+        "last_update": "2024-01-21 06:45:42"
+    },
+    "https://github.com/foxtrot-roger/comfyui-rf-nodes": {
+        "stars": 1,
+        "last_update": "2024-01-26 16:40:43"
+    },
+    "https://github.com/abyz22/image_control": {
+        "stars": 2,
+        "last_update": "2024-02-18 23:17:53"
+    },
+    "https://github.com/HAL41/ComfyUI-aichemy-nodes": {
+        "stars": 3,
+        "last_update": "2024-01-15 22:25:46"
+    },
+    "https://github.com/nkchocoai/ComfyUI-SizeFromPresets": {
+        "stars": 1,
+        "last_update": "2024-02-03 03:00:14"
+    },
+    "https://github.com/nkchocoai/ComfyUI-PromptUtilities": {
+        "stars": 5,
+        "last_update": "2024-02-21 14:47:42"
+    },
+    "https://github.com/nkchocoai/ComfyUI-TextOnSegs": {
+        "stars": 3,
+        "last_update": "2024-02-12 06:05:47"
+    },
+    "https://github.com/nkchocoai/ComfyUI-SaveImageWithMetaData": {
+        "stars": 1,
+        "last_update": "2024-03-30 04:12:19"
+    },
+    "https://github.com/nkchocoai/ComfyUI-Dart": {
+        "stars": 9,
+        "last_update": "2024-03-24 07:26:03"
+    },
+    "https://github.com/JaredTherriault/ComfyUI-JNodes": {
+        "stars": 4,
+        "last_update": "2024-03-29 21:14:13"
+    },
+    "https://github.com/prozacgod/comfyui-pzc-multiworkspace": {
+        "stars": 6,
+        "last_update": "2024-01-16 23:08:26"
+    },
+    "https://github.com/Siberpone/lazy-pony-prompter": {
+        "stars": 14,
+        "last_update": "2024-03-30 05:31:25"
+    },
+    "https://github.com/dave-palt/comfyui_DSP_imagehelpers": {
+        "stars": 0,
+        "last_update": "2024-01-18 04:59:26"
+    },
+    "https://github.com/Inzaniak/comfyui-ranbooru": {
+        "stars": 4,
+        "last_update": "2024-02-25 10:30:59"
+    },
+    "https://github.com/Miosp/ComfyUI-FBCNN": {
+        "stars": 3,
+        "last_update": "2024-01-19 21:30:27"
+    },
+    "https://github.com/JcandZero/ComfyUI_GLM4Node": {
+        "stars": 21,
+        "last_update": "2024-02-21 01:48:08"
+    },
+    "https://github.com/darkpixel/darkprompts": {
+        "stars": 3,
+        "last_update": "2024-03-25 15:42:28"
+    },
+    "https://github.com/shiimizu/ComfyUI-PhotoMaker-Plus": {
+        "stars": 127,
+        "last_update": "2024-02-16 01:18:34"
+    },
+    "https://github.com/QaisMalkawi/ComfyUI-QaisHelper": {
+        "stars": 0,
+        "last_update": "2024-01-22 10:39:27"
+    },
+    "https://github.com/longgui0318/comfyui-mask-util": {
+        "stars": 1,
+        "last_update": "2024-02-29 14:34:55"
+    },
+    "https://github.com/longgui0318/comfyui-llm-assistant": {
+        "stars": 3,
+        "last_update": "2024-03-01 02:57:07"
+    },
+    "https://github.com/longgui0318/comfyui-oms-diffusion": {
+        "stars": 3,
+        "last_update": "2024-04-01 08:57:33"
+    },
+    "https://github.com/DimaChaichan/LAizypainter-Exporter-ComfyUI": {
+        "stars": 6,
+        "last_update": "2024-02-08 13:57:21"
+    },
+    "https://github.com/adriflex/ComfyUI_Blender_Texdiff": {
+        "stars": 0,
+        "last_update": "2024-01-26 10:25:05"
+    },
+    "https://github.com/Shraknard/ComfyUI-Remover": {
+        "stars": 4,
+        "last_update": "2024-01-23 23:14:23"
+    },
+    "https://github.com/FlyingFireCo/tiled_ksampler": {
+        "stars": 52,
+        "last_update": "2023-08-13 23:05:26"
+    },
+    "https://github.com/Nlar/ComfyUI_CartoonSegmentation": {
+        "stars": 6,
+        "last_update": "2024-01-25 23:17:51"
+    },
+    "https://github.com/godspede/ComfyUI_Substring": {
+        "stars": 0,
+        "last_update": "2024-01-26 06:28:40"
+    },
+    "https://github.com/gokayfem/ComfyUI_VLM_nodes": {
+        "stars": 151,
+        "last_update": "2024-03-26 11:46:29"
+    },
+    "https://github.com/gokayfem/ComfyUI-Dream-Interpreter": {
+        "stars": 45,
+        "last_update": "2024-03-24 22:26:17"
+    },
+    "https://github.com/gokayfem/ComfyUI-Depth-Visualization": {
+        "stars": 39,
+        "last_update": "2024-03-24 04:03:08"
+    },
+    "https://github.com/gokayfem/ComfyUI-Texture-Simple": {
+        "stars": 25,
+        "last_update": "2024-03-24 22:20:21"
+    },
+    "https://github.com/Hiero207/ComfyUI-Hiero-Nodes": {
+        "stars": 1,
+        "last_update": "2024-02-11 17:17:06"
+    },
+    "https://github.com/azure-dragon-ai/ComfyUI-ClipScore-Nodes": {
+        "stars": 0,
+        "last_update": "2024-01-26 08:38:39"
+    },
+    "https://github.com/yuvraj108c/ComfyUI-Whisper": {
+        "stars": 20,
+        "last_update": "2024-02-05 08:32:57"
+    },
+    "https://github.com/blepping/ComfyUI-bleh": {
+        "stars": 13,
+        "last_update": "2024-03-18 23:50:09"
+    },
+    "https://github.com/blepping/ComfyUI-sonar": {
+        "stars": 20,
+        "last_update": "2024-04-01 17:59:36"
+    },
+    "https://github.com/JerryOrbachJr/ComfyUI-RandomSize": {
+        "stars": 2,
+        "last_update": "2024-02-14 20:36:01"
+    },
+    "https://github.com/jamal-alkharrat/ComfyUI_rotate_image": {
+        "stars": 0,
+        "last_update": "2024-01-27 15:25:00"
+    },
+    "https://github.com/mape/ComfyUI-mape-Helpers": {
+        "stars": 63,
+        "last_update": "2024-02-07 16:58:47"
+    },
+    "https://github.com/zhongpei/Comfyui_image2prompt": {
+        "stars": 149,
+        "last_update": "2024-03-27 03:29:23"
+    },
+    "https://github.com/zhongpei/ComfyUI-InstructIR": {
+        "stars": 52,
+        "last_update": "2024-02-01 06:40:40"
+    },
+    "https://github.com/Loewen-Hob/rembg-comfyui-node-better": {
+        "stars": 21,
+        "last_update": "2024-01-29 16:03:36"
+    },
+    "https://github.com/HaydenReeve/ComfyUI-Better-Strings": {
+        "stars": 0,
+        "last_update": "2024-02-05 15:48:43"
+    },
+    "https://github.com/StartHua/ComfyUI_Seg_VITON": {
+        "stars": 139,
+        "last_update": "2024-02-07 05:33:39"
+    },
+    "https://github.com/StartHua/Comfyui_joytag": {
+        "stars": 9,
+        "last_update": "2024-02-12 04:13:41"
+    },
+    "https://github.com/StartHua/Comfyui_segformer_b2_clothes": {
+        "stars": 17,
+        "last_update": "2024-02-19 16:02:10"
+    },
+    "https://github.com/StartHua/ComfyUI_OOTDiffusion_CXH": {
+        "stars": 70,
+        "last_update": "2024-03-04 09:33:57"
+    },
+    "https://github.com/ricklove/comfyui-ricklove": {
+        "stars": 0,
+        "last_update": "2024-02-01 02:50:59"
+    },
+    "https://github.com/nosiu/comfyui-instantId-faceswap": {
+        "stars": 133,
+        "last_update": "2024-02-25 13:58:50"
+    },
+    "https://github.com/LyazS/comfyui-anime-seg": {
+        "stars": 3,
+        "last_update": "2024-02-03 16:45:06"
+    },
+    "https://github.com/Chan-0312/ComfyUI-IPAnimate": {
+        "stars": 48,
+        "last_update": "2024-02-01 09:17:58"
+    },
+    "https://github.com/Chan-0312/ComfyUI-EasyDeforum": {
+        "stars": 5,
+        "last_update": "2024-03-14 02:14:56"
+    },
+    "https://github.com/trumanwong/ComfyUI-NSFW-Detection": {
+        "stars": 7,
+        "last_update": "2024-02-04 08:49:11"
+    },
+    "https://github.com/TemryL/ComfyS3": {
+        "stars": 8,
+        "last_update": "2024-02-08 16:59:15"
+    },
+    "https://github.com/davask/ComfyUI-MarasIT-Nodes": {
+        "stars": 14,
+        "last_update": "2024-04-01 08:48:30"
+    },
+    "https://github.com/yffyhk/comfyui_auto_danbooru": {
+        "stars": 0,
+        "last_update": "2024-02-04 08:09:57"
+    },
+    "https://github.com/dfl/comfyui-clip-with-break": {
+        "stars": 5,
+        "last_update": "2024-02-05 17:48:33"
+    },
+    "https://github.com/dfl/comfyui-tcd-scheduler": {
+        "stars": 50,
+        "last_update": "2024-03-24 18:29:56"
+    },
+    "https://github.com/MarkoCa1/ComfyUI_Segment_Mask": {
+        "stars": 6,
+        "last_update": "2024-03-16 06:37:47"
+    },
+    "https://github.com/antrobot1234/antrobots-comfyUI-nodepack": {
+        "stars": 8,
+        "last_update": "2024-03-06 22:34:12"
+    },
+    "https://github.com/bilal-arikan/ComfyUI_TextAssets": {
+        "stars": 2,
+        "last_update": "2024-02-06 00:30:11"
+    },
+    "https://github.com/kadirnar/ComfyUI-Transformers": {
+        "stars": 13,
+        "last_update": "2024-02-06 15:43:43"
+    },
+    "https://github.com/digitaljohn/comfyui-propost": {
+        "stars": 83,
+        "last_update": "2024-02-11 10:08:19"
+    },
+    "https://github.com/DonBaronFactory/ComfyUI-Cre8it-Nodes": {
+        "stars": 0,
+        "last_update": "2024-02-25 12:35:13"
+    },
+    "https://github.com/XmYx/deforum-comfy-nodes": {
+        "stars": 53,
+        "last_update": "2024-03-21 11:08:54"
+    },
+    "https://github.com/adbrasi/ComfyUI-TrashNodes-DownloadHuggingface": {
+        "stars": 4,
+        "last_update": "2024-02-08 21:25:17"
+    },
+    "https://github.com/mbrostami/ComfyUI-HF": {
+        "stars": 7,
+        "last_update": "2024-02-11 00:03:26"
+    },
+    "https://github.com/Billius-AI/ComfyUI-Path-Helper": {
+        "stars": 11,
+        "last_update": "2024-02-26 10:48:42"
+    },
+    "https://github.com/Franck-Demongin/NX_PromptStyler": {
+        "stars": 3,
+        "last_update": "2024-02-19 10:14:56"
+    },
+    "https://github.com/xiaoxiaodesha/hd_node": {
+        "stars": 2,
+        "last_update": "2024-02-18 05:23:57"
+    },
+    "https://github.com/ShmuelRonen/ComfyUI-SVDResizer": {
+        "stars": 1,
+        "last_update": "2024-03-08 15:16:10"
+    },
+    "https://github.com/redhottensors/ComfyUI-Prediction": {
+        "stars": 7,
+        "last_update": "2024-03-30 23:21:59"
+    },
+    "https://github.com/Mamaaaamooooo/batchImg-rembg-ComfyUI-nodes": {
+        "stars": 8,
+        "last_update": "2024-02-15 09:03:57"
+    },
+    "https://github.com/jordoh/ComfyUI-Deepface": {
+        "stars": 8,
+        "last_update": "2024-03-23 14:37:34"
+    },
+    "https://github.com/yuvraj108c/ComfyUI-Pronodes": {
+        "stars": 0,
+        "last_update": "2024-03-22 18:22:13"
+    },
+    "https://github.com/GavChap/ComfyUI-CascadeResolutions": {
+        "stars": 5,
+        "last_update": "2024-02-26 10:29:06"
+    },
+    "https://github.com/yuvraj108c/ComfyUI-Vsgan": {
+        "stars": 1,
+        "last_update": "2024-03-08 10:11:28"
+    },
+    "https://github.com/yytdfc/ComfyUI-Bedrock": {
+        "stars": 4,
+        "last_update": "2024-02-28 05:48:49"
+    },
+    "https://github.com/mirabarukaso/ComfyUI_Mira": {
+        "stars": 5,
+        "last_update": "2024-03-31 15:42:50"
+    },
+    "https://github.com/1038lab/ComfyUI-GPT2P": {
+        "stars": 3,
+        "last_update": "2024-02-21 04:45:27"
+    },
+    "https://github.com/LykosAI/ComfyUI-Inference-Core-Nodes": {
+        "stars": 4,
+        "last_update": "2024-03-25 00:54:00"
+    },
+    "https://github.com/klinter007/klinter_nodes": {
+        "stars": 2,
+        "last_update": "2024-03-26 02:58:49"
+    },
+    "https://github.com/Ludobico/ComfyUI-ScenarioPrompt": {
+        "stars": 10,
+        "last_update": "2024-03-26 01:28:07"
+    },
+    "https://github.com/logtd/ComfyUI-InstanceDiffusion": {
+        "stars": 19,
+        "last_update": "2024-03-31 19:06:57"
+    },
+    "https://github.com/logtd/ComfyUI-TrackingNodes": {
+        "stars": 5,
+        "last_update": "2024-02-24 04:43:16"
+    },
+    "https://github.com/logtd/ComfyUI-InversedNoise": {
+        "stars": 3,
+        "last_update": "2024-03-31 19:11:53"
+    },
+    "https://github.com/logtd/ComfyUI-RefSampling": {
+        "stars": 2,
+        "last_update": "2024-03-31 02:11:14"
+    },
+    "https://github.com/logtd/ComfyUI-FLATTEN": {
+        "stars": 47,
+        "last_update": "2024-04-01 01:14:36"
+    },
+    "https://github.com/Big-Idea-Technology/ComfyUI_Image_Text_Overlay": {
+        "stars": 4,
+        "last_update": "2024-02-26 15:43:54"
+    },
+    "https://github.com/Big-Idea-Technology/ComfyUI_LLM_Node": {
+        "stars": 26,
+        "last_update": "2024-03-29 07:06:45"
+    },
+    "https://github.com/Guillaume-Fgt/ComfyUI_StableCascadeLatentRatio": {
+        "stars": 3,
+        "last_update": "2024-02-26 09:37:16"
+    },
+    "https://github.com/AuroBit/ComfyUI-OOTDiffusion": {
+        "stars": 214,
+        "last_update": "2024-03-26 02:44:57"
+    },
+    "https://github.com/AuroBit/ComfyUI-AnimateAnyone-reproduction": {
+        "stars": 32,
+        "last_update": "2024-02-29 10:19:36"
+    },
+    "https://github.com/czcz1024/Comfyui-FaceCompare": {
+        "stars": 0,
+        "last_update": "2024-02-23 09:08:32"
+    },
+    "https://github.com/TheBill2001/comfyui-upscale-by-model": {
+        "stars": 0,
+        "last_update": "2024-02-24 00:49:19"
+    },
+    "https://github.com/leoleelxh/ComfyUI-LLMs": {
+        "stars": 6,
+        "last_update": "2024-03-07 07:34:10"
+    },
+    "https://github.com/hughescr/ComfyUI-OpenPose-Keypoint-Extractor": {
+        "stars": 1,
+        "last_update": "2024-02-24 21:41:24"
+    },
+    "https://github.com/jkrauss82/ultools-comfyui": {
+        "stars": 1,
+        "last_update": "2024-03-31 08:27:34"
+    },
+    "https://github.com/hiforce/comfyui-hiforce-plugin": {
+        "stars": 2,
+        "last_update": "2024-02-29 09:35:31"
+    },
+    "https://github.com/RomanKuschanow/ComfyUI-Advanced-Latent-Control": {
+        "stars": 10,
+        "last_update": "2024-04-01 21:06:51"
+    },
+    "https://github.com/guill/abracadabra-comfyui": {
+        "stars": 1,
+        "last_update": "2024-02-26 04:25:21"
+    },
+    "https://github.com/cerspense/ComfyUI_cspnodes": {
+        "stars": 16,
+        "last_update": "2024-03-23 14:40:21"
+    },
+    "https://github.com/qwixiwp/queuetools": {
+        "stars": 0,
+        "last_update": "2024-02-26 19:21:00"
+    },
+    "https://github.com/Chan-0312/ComfyUI-Prompt-Preview": {
+        "stars": 6,
+        "last_update": "2024-02-27 11:30:38"
+    },
+    "https://github.com/Munkyfoot/ComfyUI-TextOverlay": {
+        "stars": 0,
+        "last_update": "2024-02-27 22:56:42"
+    },
+    "https://github.com/holchan/ComfyUI-ModelDownloader": {
+        "stars": 2,
+        "last_update": "2024-03-02 05:43:41"
+    },
+    "https://github.com/Alysondao/Comfyui-Yolov8-JSON": {
+        "stars": 8,
+        "last_update": "2024-03-04 07:34:39"
+    },
+    "https://github.com/CC-BryanOttho/ComfyUI_API_Manager": {
+        "stars": 3,
+        "last_update": "2024-02-27 23:31:45"
+    },
+    "https://github.com/maracman/ComfyUI-SubjectStyle-CSV": {
+        "stars": 2,
+        "last_update": "2024-02-29 19:40:01"
+    },
+    "https://github.com/438443467/ComfyUI-GPT4V-Image-Captioner": {
+        "stars": 7,
+        "last_update": "2024-03-29 10:30:27"
+    },
+    "https://github.com/uetuluk/comfyui-webcam-node": {
+        "stars": 0,
+        "last_update": "2024-03-01 07:25:27"
+    },
+    "https://github.com/huchenlei/ComfyUI-layerdiffuse": {
+        "stars": 944,
+        "last_update": "2024-03-09 21:16:31"
+    },
+    "https://github.com/huchenlei/ComfyUI_DanTagGen": {
+        "stars": 29,
+        "last_update": "2024-03-23 19:40:34"
+    },
+    "https://github.com/nathannlu/ComfyUI-Pets": {
+        "stars": 31,
+        "last_update": "2024-03-31 23:55:42"
+    },
+    "https://github.com/nathannlu/ComfyUI-Cloud": {
+        "stars": 103,
+        "last_update": "2024-03-31 06:00:13"
+    },
+    "https://github.com/11dogzi/Comfyui-ergouzi-Nodes": {
+        "stars": 3,
+        "last_update": "2024-03-12 02:03:09"
+    },
+    "https://github.com/BXYMartin/ComfyUI-InstantIDUtils": {
+        "stars": 3,
+        "last_update": "2024-03-04 16:42:02"
+    },
+    "https://github.com/cdb-boop/comfyui-image-round": {
+        "stars": 0,
+        "last_update": "2024-03-07 07:35:43"
+    },
+    "https://github.com/cdb-boop/ComfyUI-Bringing-Old-Photos-Back-to-Life": {
+        "stars": 4,
+        "last_update": "2024-03-27 21:37:34"
+    },
+    "https://github.com/atmaranto/ComfyUI-SaveAsScript": {
+        "stars": 5,
+        "last_update": "2024-03-20 08:47:51"
+    },
+    "https://github.com/meshmesh-io/mm-comfyui-megamask": {
+        "stars": 0,
+        "last_update": "2024-03-07 23:59:12"
+    },
+    "https://github.com/meshmesh-io/mm-comfyui-loopback": {
+        "stars": 0,
+        "last_update": "2024-03-07 19:46:37"
+    },
+    "https://github.com/meshmesh-io/ComfyUI-MeshMesh": {
+        "stars": 0,
+        "last_update": "2024-03-12 17:19:32"
+    },
+    "https://github.com/cozymantis/human-parser-comfyui-node": {
+        "stars": 18,
+        "last_update": "2024-03-08 22:47:18"
+    },
+    "https://github.com/cozymantis/pose-generator-comfyui-node": {
+        "stars": 10,
+        "last_update": "2024-03-13 14:59:23"
+    },
+    "https://github.com/cozymantis/cozy-utils-comfyui-nodes": {
+        "stars": 3,
+        "last_update": "2024-03-13 11:25:27"
+    },
+    "https://github.com/vivax3794/ComfyUI-Vivax-Nodes": {
+        "stars": 3,
+        "last_update": "2024-03-17 22:02:48"
+    },
+    "https://github.com/victorchall/comfyui_webcamcapture": {
+        "stars": 1,
+        "last_update": "2024-03-06 18:33:39"
+    },
+    "https://github.com/ljleb/comfy-mecha": {
+        "stars": 4,
+        "last_update": "2024-03-24 21:52:17"
+    },
+    "https://github.com/diStyApps/ComfyUI_FrameMaker": {
+        "stars": 6,
+        "last_update": "2024-03-08 09:19:43"
+    },
+    "https://github.com/hackkhai/ComfyUI-Image-Matting": {
+        "stars": 8,
+        "last_update": "2024-03-09 06:30:39"
+    },
+    "https://github.com/Pos13/comfyui-cyclist": {
+        "stars": 6,
+        "last_update": "2024-03-23 17:33:44"
+    },
+    "https://github.com/ExponentialML/ComfyUI_ModelScopeT2V": {
+        "stars": 16,
+        "last_update": "2024-03-09 00:02:47"
+    },
+    "https://github.com/ExponentialML/ComfyUI_Native_DynamiCrafter": {
+        "stars": 52,
+        "last_update": "2024-03-23 02:32:04"
+    },
+    "https://github.com/ExponentialML/ComfyUI_VisualStylePrompting": {
+        "stars": 191,
+        "last_update": "2024-03-31 23:38:23"
+    },
+    "https://github.com/angeloshredder/StableCascadeResizer": {
+        "stars": 0,
+        "last_update": "2024-03-08 22:53:27"
+    },
+    "https://github.com/stavsap/comfyui-ollama": {
+        "stars": 12,
+        "last_update": "2024-03-15 08:41:19"
+    },
+    "https://github.com/dchatel/comfyui_facetools": {
+        "stars": 11,
+        "last_update": "2024-03-13 11:20:57"
+    },
+    "https://github.com/ggpid/idpark_custom_node": {
+        "stars": 0,
+        "last_update": "2024-03-12 03:41:34"
+    },
+    "https://github.com/prodogape/ComfyUI-Minio": {
+        "stars": 1,
+        "last_update": "2024-03-09 07:44:51"
+    },
+    "https://github.com/AIGCTeam/ComfyUI_kkTranslator_nodes": {
+        "stars": 1,
+        "last_update": "2024-02-22 08:30:33"
+    },
+    "https://github.com/vsevolod-oparin/comfyui-kandinsky22": {
+        "stars": 5,
+        "last_update": "2024-03-17 00:05:27"
+    },
+    "https://github.com/Xyem/Xycuno-Oobabooga": {
+        "stars": 1,
+        "last_update": "2024-03-12 19:50:18"
+    },
+    "https://github.com/shi3z/ComfyUI_Memeplex_DALLE": {
+        "stars": 2,
+        "last_update": "2024-03-13 08:26:09"
+    },
+    "https://github.com/if-ai/ComfyUI-IF_AI_tools": {
+        "stars": 85,
+        "last_update": "2024-03-30 02:20:02"
+    },
+    "https://github.com/dmMaze/sketch2manga": {
+        "stars": 10,
+        "last_update": "2024-03-14 05:44:16"
+    },
+    "https://github.com/olduvai-jp/ComfyUI-HfLoader": {
+        "stars": 1,
+        "last_update": "2024-03-18 04:57:05"
+    },
+    "https://github.com/AiMiDi/ComfyUI-Aimidi-nodes": {
+        "stars": 0,
+        "last_update": "2024-03-31 14:14:24"
+    },
+    "https://github.com/ForeignGods/ComfyUI-Mana-Nodes": {
+        "stars": 136,
+        "last_update": "2024-04-01 16:51:37"
+    },
+    "https://github.com/madtunebk/ComfyUI-ControlnetAux": {
+        "stars": 5,
+        "last_update": "2024-03-16 13:52:32"
+    },
+    "https://github.com/MarkoCa1/ComfyUI-Text": {
+        "stars": 2,
+        "last_update": "2024-03-16 06:25:38"
+    },
+    "https://github.com/Shadetail/ComfyUI_Eagleshadow": {
+        "stars": 0,
+        "last_update": "2024-03-14 10:02:22"
+    },
+    "https://github.com/ArdeniusAI/CPlus_Ardenius": {
+        "stars": 0,
+        "last_update": "2024-03-28 02:21:05"
+    },
+    "https://github.com/Jannchie/ComfyUI-J": {
+        "stars": 46,
+        "last_update": "2024-03-24 06:35:19"
+    },
+    "https://github.com/daxcay/ComfyUI-JDCN": {
+        "stars": 3,
+        "last_update": "2024-03-30 19:14:48"
+    },
+    "https://github.com/Seedsa/Fooocus_Nodes": {
+        "stars": 14,
+        "last_update": "2024-03-28 07:37:38"
+    },
+    "https://github.com/zhangp365/ComfyUI-utils-nodes": {
+        "stars": 0,
+        "last_update": "2024-03-28 08:13:46"
+    },
+    "https://github.com/ratulrafsan/Comfyui-SAL-VTON": {
+        "stars": 13,
+        "last_update": "2024-03-22 04:31:59"
+    },
+    "https://github.com/Nevysha/ComfyUI-nevysha-top-menu": {
+        "stars": 2,
+        "last_update": "2024-03-23 10:48:36"
+    },
+    "https://github.com/alisson-anjos/ComfyUI-LLaVA-Describer": {
+        "stars": 8,
+        "last_update": "2024-03-31 15:13:33"
+    },
+    "https://github.com/chaosaiart/Chaosaiart-Nodes": {
+        "stars": 7,
+        "last_update": "2024-03-31 12:41:40"
+    },
+    "https://github.com/viperyl/ComfyUI-BiRefNet": {
+        "stars": 107,
+        "last_update": "2024-03-25 11:02:49"
+    },
+    "https://github.com/SuperBeastsAI/ComfyUI-SuperBeasts": {
+        "stars": 54,
+        "last_update": "2024-04-02 00:18:19"
+    },
+    "https://github.com/IKHOR/ComfyUI-IKHOR-Jam-Nodes": {
+        "stars": 0,
+        "last_update": "2024-03-26 16:55:10"
+    },
+    "https://github.com/yuvraj108c/ComfyUI-Depth-Anything-Tensorrt": {
+        "stars": 23,
+        "last_update": "2024-03-30 11:08:23"
+    },
+    "https://github.com/hay86/ComfyUI_Dreamtalk": {
+        "stars": 0,
+        "last_update": "2024-04-02 04:15:50"
+    },
+    "https://github.com/shinich39/comfyui-load-image-39": {
+        "stars": 1,
+        "last_update": "2024-03-30 19:44:53"
+    },
+    "https://github.com/shinich39/comfyui-ramdom-node-39": {
+        "stars": 1,
+        "last_update": "2024-03-31 19:53:05"
+    },
+    "https://github.com/wei30172/comfygen": {
+        "stars": 1,
+        "last_update": "2024-03-28 14:03:32"
+    },
+    "https://github.com/zombieyang/sd-ppp": {
+        "stars": 2,
+        "last_update": "2024-03-30 03:24:34"
+    },
+    "https://github.com/KytraScript/ComfyUI_KytraWebhookHTTP": {
+        "stars": 2,
+        "last_update": "2024-03-29 06:08:53"
+    },
+    "https://github.com/1mckw/Comfyui-Gelbooru": {
+        "stars": 1,
+        "last_update": "2024-03-29 04:22:07"
+    },
+    "https://github.com/NeuralSamurAI/Comfyui-Superprompt-Unofficial": {
+        "stars": 24,
+        "last_update": "2024-03-30 22:07:58"
+    },
+    "https://github.com/MokkaBoss1/ComfyUI_Mokkaboss1": {
+        "stars": 0,
+        "last_update": "2024-03-31 20:39:40"
+    },
+    "https://github.com/jiaxiangc/ComfyUI-ResAdapter": {
+        "stars": 178,
+        "last_update": "2024-04-01 03:35:41"
+    },
+    "https://github.com/ParisNeo/lollms_nodes_suite": {
+        "stars": 5,
+        "last_update": "2024-03-31 21:59:30"
+    },
+    "https://github.com/IsItDanOrAi/ComfyUI-Stereopsis": {
+        "stars": 1,
+        "last_update": "2024-03-20 21:56:10"
+    },
+    "https://github.com/nickve28/nich-comfy-utils": {
+        "stars": 1,
+        "last_update": "2024-04-01 19:53:42"
+    },
+    "https://github.com/frankchieng/ComfyUI_Aniportrait": {
+        "stars": 8,
+        "last_update": "2024-04-02 05:12:34"
+    },
+    "https://github.com/BlakeOne/ComfyUI-SchedulerMixer": {
+        "stars": 3,
+        "last_update": "2024-04-01 06:13:32"
+    },
+    "https://github.com/BlakeOne/ComfyUI-FastImageListToImageBatch": {
+        "stars": 0,
+        "last_update": "2024-04-01 01:09:41"
+    },
+    "https://github.com/kale4eat/ComfyUI-path-util": {
+        "stars": 0,
+        "last_update": "2024-04-01 01:33:56"
+    },
+    "https://github.com/kale4eat/ComfyUI-string-util": {
+        "stars": 0,
+        "last_update": "2024-04-01 01:33:13"
+    },
+    "https://github.com/kale4eat/ComfyUI-text-file-util": {
+        "stars": 0,
+        "last_update": "2024-04-01 01:32:04"
+    },
+    "https://github.com/comfyanonymous/ComfyUI": {
+        "stars": 30438,
+        "last_update": "2024-04-01 22:09:26"
+    }
+}

--- a/js/custom-nodes-downloader.js
+++ b/js/custom-nodes-downloader.js
@@ -109,6 +109,9 @@ export class CustomNodesInstaller extends ComfyDialog {
 		this.manager_dialog = manager_dialog;
 		this.search_keyword = '';
 		this.element = $el("div.comfy-modal", { parent: document.body }, []);
+
+		this.currentSortProperty = ''; // The property currently being sorted
+		this.currentSortAscending = true; // The direction of the current sort		
 	}
 
 	startInstall(target) {
@@ -367,76 +370,164 @@ export class CustomNodesInstaller extends ComfyDialog {
 		}
 	}
 
+	sortData(property, ascending = true) {
+		this.data.sort((a, b) => {
+			// Check if either value is -1 and handle accordingly
+			if (a[property] === -1) return 1; // Always put a at the end if its value is -1
+			if (b[property] === -1) return -1; // Always put b at the end if its value is -1
+			// And be careful here, (-1<'2024-01-01') and (-1>'2024-01-01') are both false! So I handle -1 seperately.
+			if (a[property] < b[property]) return ascending ? -1 : 1;
+			if (a[property] > b[property]) return ascending ? 1 : -1;
+			return 0;
+		});
+	}
+
+	resetHeaderStyles() {
+		const headers = ['th_stars', 'th_last_update']; // Add the IDs of all your sortable headers here
+		headers.forEach(headerId => {
+			const header = this.element.querySelector(`#${headerId}`);
+			if (header) {
+				header.style.backgroundColor = ''; // Reset to default background color
+				// Add other style resets if necessary
+			}
+		});
+	}
+	
+	toggleSort(property) {
+		// If currently sorted by this property, toggle the direction; else, sort ascending
+		if (this.currentSortProperty === property) {
+			this.currentSortAscending = !this.currentSortAscending;
+		} else {
+			this.currentSortAscending = false;
+		}
+		this.currentSortProperty = property;
+	
+		this.resetHeaderStyles(); // Reset styles of all sortable headers
+
+		// Determine the ID of the header based on the property
+		let headerId = '';
+		if (property === 'stars') {
+			headerId = 'th_stars';
+		} else if (property === 'last_update') {
+			headerId = 'th_last_update';
+		}
+
+		// If we have a valid headerId, change its style to indicate it's the active sort column
+		if (headerId) {
+			const activeHeader = this.element.querySelector(`#${headerId}`);
+			if (activeHeader) {
+				activeHeader.style.backgroundColor = '#222';
+				// Slightly brighter. Add other style changes if necessary.
+			}
+		}
+		
+		// Call sortData with the current property and direction
+		this.sortData(property, this.currentSortAscending);
+	
+		// Refresh the grid to display sorted data
+		this.createGrid();
+	}
+
 	async createGrid() {
-		var grid = document.createElement('table');
-		grid.setAttribute('id', 'custom-nodes-grid');
-
-		this.grid_rows = {};
-
+		// Remove existing table if present
+		var grid = this.element.querySelector('#custom-nodes-grid');
+		var panel;
 		let self = this;
+		if (grid) {
+			grid.querySelector('tbody').remove();
+			panel = grid.parentNode;
+		} else {
+			grid = document.createElement('table');
+			grid.setAttribute('id', 'custom-nodes-grid');
 
-		var thead = document.createElement('thead');
+			this.grid_rows = {};
+
+			var thead = document.createElement('thead');
+
+			var headerRow = document.createElement('tr');
+			thead.style.position = "sticky";
+			thead.style.top = "0px";
+			thead.style.borderCollapse = "collapse";
+			thead.style.tableLayout = "fixed";
+
+			var header0 = document.createElement('th');
+			header0.style.width = "20px";
+			this.checkbox_all = $el("input",{type:'checkbox', id:'check_all'},[]);
+			header0.appendChild(this.checkbox_all);
+			this.checkbox_all.checked = false;
+			this.checkbox_all.disabled = true;
+			this.checkbox_all.addEventListener('change', function() { self.check_all.call(self, self.checkbox_all.checked); });
+
+			var header1 = document.createElement('th');
+			header1.innerHTML = '&nbsp;&nbsp;ID&nbsp;&nbsp;';
+			header1.style.width = "20px";
+			var header2 = document.createElement('th');
+			header2.innerHTML = 'Author';
+			header2.style.width = "150px";
+			var header3 = document.createElement('th');
+			header3.innerHTML = 'Name';
+			header3.style.width = "20%";
+			var header4 = document.createElement('th');
+			header4.innerHTML = 'Description';
+			header4.style.width = "60%";
+	//		header4.classList.add('expandable-column');
+			var header5 = document.createElement('th');
+			header5.innerHTML = 'GitHub Stars';
+			header5.style.width = "130px";
+			header5.setAttribute('id', 'th_stars');
+			header5.style.cursor = 'pointer';
+			header5.onclick = () => this.toggleSort('stars');
+			var header6 = document.createElement('th');
+			header6.innerHTML = 'Last Update';
+			header6.style.width = "130px";
+			header6.setAttribute('id', 'th_last_update');
+			header6.style.cursor = 'pointer';
+			header6.onclick = () => this.toggleSort('last_update');
+			var header7 = document.createElement('th');
+			header7.innerHTML = 'Install';
+			header7.style.width = "130px";
+
+			header0.style.position = "sticky";
+			header0.style.top = "0px";
+			header1.style.position = "sticky";
+			header1.style.top = "0px";
+			header2.style.position = "sticky";
+			header2.style.top = "0px";
+			header3.style.position = "sticky";
+			header3.style.top = "0px";
+			header4.style.position = "sticky";
+			header4.style.top = "0px";
+			header5.style.position = "sticky";
+			header5.style.top = "0px";
+			header6.style.position = "sticky";
+			header6.style.top = "0px";
+			header7.style.position = "sticky";
+			header7.style.top = "0px";
+
+			thead.appendChild(headerRow);
+			headerRow.appendChild(header0);
+			headerRow.appendChild(header1);
+			headerRow.appendChild(header2);
+			headerRow.appendChild(header3);
+			headerRow.appendChild(header4);
+			headerRow.appendChild(header5);
+			headerRow.appendChild(header6);
+			headerRow.appendChild(header7);
+
+			headerRow.style.backgroundColor = "Black";
+			headerRow.style.color = "White";
+			headerRow.style.textAlign = "center";
+			headerRow.style.width = "100%";
+			headerRow.style.padding = "0";
+
+			grid.appendChild(thead);
+
+			panel = document.createElement('div');
+			panel.style.width = "100%";
+			panel.appendChild(grid);
+			this.element.appendChild(panel);
+		}
 		var tbody = document.createElement('tbody');
-
-		var headerRow = document.createElement('tr');
-		thead.style.position = "sticky";
-		thead.style.top = "0px";
-		thead.style.borderCollapse = "collapse";
-		thead.style.tableLayout = "fixed";
-
-		var header0 = document.createElement('th');
-		header0.style.width = "20px";
-		this.checkbox_all = $el("input",{type:'checkbox', id:'check_all'},[]);
-		header0.appendChild(this.checkbox_all);
-		this.checkbox_all.checked = false;
-		this.checkbox_all.disabled = true;
-		this.checkbox_all.addEventListener('change', function() { self.check_all.call(self, self.checkbox_all.checked); });
-
-		var header1 = document.createElement('th');
-		header1.innerHTML = '&nbsp;&nbsp;ID&nbsp;&nbsp;';
-		header1.style.width = "20px";
-		var header2 = document.createElement('th');
-		header2.innerHTML = 'Author';
-		header2.style.width = "150px";
-		var header3 = document.createElement('th');
-		header3.innerHTML = 'Name';
-		header3.style.width = "20%";
-		var header4 = document.createElement('th');
-		header4.innerHTML = 'Description';
-		header4.style.width = "60%";
-//		header4.classList.add('expandable-column');
-		var header5 = document.createElement('th');
-		header5.innerHTML = 'Install';
-		header5.style.width = "130px";
-
-		header0.style.position = "sticky";
-		header0.style.top = "0px";
-		header1.style.position = "sticky";
-		header1.style.top = "0px";
-		header2.style.position = "sticky";
-		header2.style.top = "0px";
-		header3.style.position = "sticky";
-		header3.style.top = "0px";
-		header4.style.position = "sticky";
-		header4.style.top = "0px";
-		header5.style.position = "sticky";
-		header5.style.top = "0px";
-
-		thead.appendChild(headerRow);
-		headerRow.appendChild(header0);
-		headerRow.appendChild(header1);
-		headerRow.appendChild(header2);
-		headerRow.appendChild(header3);
-		headerRow.appendChild(header4);
-		headerRow.appendChild(header5);
-
-		headerRow.style.backgroundColor = "Black";
-		headerRow.style.color = "White";
-		headerRow.style.textAlign = "center";
-		headerRow.style.width = "100%";
-		headerRow.style.padding = "0";
-
-		grid.appendChild(thead);
 		grid.appendChild(tbody);
 
 		if(this.data)
@@ -499,7 +590,26 @@ export class CustomNodesInstaller extends ComfyDialog {
 				}
 
 				var data5 = document.createElement('td');
+				data5.style.maxWidth = "100px";
+				data5.className = "cm-node-stars"
+				data5.textContent = `${data.stars}`;
+				data5.style.whiteSpace = "nowrap";
+				data5.style.overflow = "hidden";
+				data5.style.textOverflow = "ellipsis";
 				data5.style.textAlign = "center";
+
+				var lastUpdateDate = new Date();
+				var data6 = document.createElement('td');
+				data6.style.maxWidth = "100px";
+				data6.className = "cm-node-last-update"
+				data6.textContent = `${data.last_update}`.split(' ')[0];
+				data6.style.whiteSpace = "nowrap";
+				data6.style.overflow = "hidden";
+				data6.style.textOverflow = "ellipsis";
+				data6.style.textAlign = "center";
+
+				var data7 = document.createElement('td');
+				data7.style.textAlign = "center";
 
 				var installBtn = document.createElement('button');
 				installBtn.className = "cm-btn-install";
@@ -587,7 +697,7 @@ export class CustomNodesInstaller extends ComfyDialog {
 						install_checked_custom_node(self.grid_rows, j, CustomNodesInstaller.instance, 'update');
 					});
 
-					data5.appendChild(installBtn2);
+					data7.appendChild(installBtn2);
 				}
 
 				if(installBtn3 != null) {
@@ -596,7 +706,7 @@ export class CustomNodesInstaller extends ComfyDialog {
 						install_checked_custom_node(self.grid_rows, j, CustomNodesInstaller.instance, 'toggle_active');
 					});
 
-					data5.appendChild(installBtn3);
+					data7.appendChild(installBtn3);
 				}
 
 				if(installBtn4 != null) {
@@ -605,7 +715,7 @@ export class CustomNodesInstaller extends ComfyDialog {
 						install_checked_custom_node(self.grid_rows, j, CustomNodesInstaller.instance, 'fix');
 					});
 
-					data5.appendChild(installBtn4);
+					data7.appendChild(installBtn4);
 				}
 
 				installBtn.style.width = "120px";
@@ -621,7 +731,7 @@ export class CustomNodesInstaller extends ComfyDialog {
 				});
 
 				if(!data.author.startsWith('#NOTICE')){
-					data5.appendChild(installBtn);
+					data7.appendChild(installBtn);
 				}
 
 				if(data.installed == 'Fail' || data.author.startsWith('#NOTICE'))
@@ -637,6 +747,8 @@ export class CustomNodesInstaller extends ComfyDialog {
 				dataRow.appendChild(data3);
 				dataRow.appendChild(data4);
 				dataRow.appendChild(data5);
+				dataRow.appendChild(data6);
+				dataRow.appendChild(data7);
 				tbody.appendChild(dataRow);
 
 				let buttons = [];
@@ -653,10 +765,6 @@ export class CustomNodesInstaller extends ComfyDialog {
 				this.grid_rows[i] = {data:data, buttons:buttons, checkbox:checkbox, control:dataRow};
 			}
 
-		const panel = document.createElement('div');
-		panel.style.width = "100%";
-		panel.appendChild(grid);
-
 		function handleResize() {
 		  const parentHeight = self.element.clientHeight;
 		  const gridHeight = parentHeight - 200;
@@ -672,7 +780,6 @@ export class CustomNodesInstaller extends ComfyDialog {
 		grid.style.overflowY = "scroll";
 		this.element.style.height = "85%";
 		this.element.style.width = "80%";
-		this.element.appendChild(panel);
 
 		handleResize();
 	}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 GitPython
+PyGithub
 matrix-client==0.4.0
 transformers
 huggingface-hub>0.20

--- a/scanner.py
+++ b/scanner.py
@@ -10,6 +10,10 @@ builtin_nodes = set()
 
 import sys
 
+from urllib.parse import urlparse
+from github import Github
+
+g = Github(os.environ.get('GITHUB_TOKEN'))
 
 # prepare temp dir
 if len(sys.argv) > 1:
@@ -224,7 +228,48 @@ def update_custom_nodes():
         if not skip_update:
             clone_or_pull_git_repository(url)
 
-    with concurrent.futures.ThreadPoolExecutor(10) as executor:
+    def process_git_stats(git_url_titles_preemptions):
+        GITHUB_STATS_CACHE_FILENAME = 'github-stats-cache.json'
+        GITHUB_STATS_FILENAME = 'github-stats.json'
+
+        github_stats = {}
+        try:
+            with open(GITHUB_STATS_CACHE_FILENAME, 'r', encoding='utf-8') as file:
+                github_stats = json.load(file)
+        except FileNotFoundError:
+            pass
+        for url, title, preemptions, node_pattern in git_url_titles_preemptions:
+            if url not in github_stats:
+                # Parsing the URL
+                parsed_url = urlparse(url)
+                domain = parsed_url.netloc
+                path = parsed_url.path
+                path_parts = path.strip("/").split("/")
+                if len(path_parts) >= 2 and domain == "github.com":
+                    owner_repo = "/".join(path_parts[-2:])
+                    repo = g.get_repo(owner_repo)
+
+                    last_update = repo.pushed_at.strftime("%Y-%m-%d %H:%M:%S") if repo.pushed_at else 'N/A'
+                    github_stats[url] = {
+                        "stars": repo.stargazers_count,
+                        "last_update": last_update,
+                    }
+                    with open(GITHUB_STATS_CACHE_FILENAME, 'w', encoding='utf-8') as file:
+                        json.dump(github_stats, file, ensure_ascii=False, indent=4)
+                    # print(f"Title: {title}, Stars: {repo.stargazers_count}, Last Update: {last_update}")
+                else:
+                    print(f"Invalid URL format for GitHub repository: {url}")
+
+        with open(GITHUB_STATS_FILENAME, 'w', encoding='utf-8') as file:
+            json.dump(github_stats, file, ensure_ascii=False, indent=4)
+        print(f"Successfully written to {GITHUB_STATS_FILENAME}, removing {GITHUB_STATS_CACHE_FILENAME}.")
+        try:
+            os.remove(GITHUB_STATS_CACHE_FILENAME) # This cache file is just for avoiding failure of GitHub API fetch, so it is safe to remove.
+        except:
+            pass
+
+    with concurrent.futures.ThreadPoolExecutor(11) as executor:
+        executor.submit(process_git_stats, git_url_titles_preemptions) # One single thread for `process_git_stats()`. Runs concurrently with `process_git_url_title()`.
         for url, title, preemptions, node_pattern in git_url_titles_preemptions:
             executor.submit(process_git_url_title, url, title, preemptions, node_pattern)
 


### PR DESCRIPTION
This pull request adds functionality to fetch and display GitHub stats as part of the custom node list enhancement. It addresses the feature request and feedback discussed in issue #497.

Changes include:
- Adding the PyGithub package to requirements.txt for GitHub API interaction.
- Updating .gitignore to exclude the github-stats-cache.json file.
- Implementing a new GitHub stats fetching feature in scanner.py.
- Adding a new file, github-stats.json, for storing fetched GitHub stats.

These changes aim to improve the user experience by allowing sorting by popularity and facilitating easier selection and installation of popular nodes.

Thanks!
