### PR TITLE
A quick fix to ensure that the filter, search, and sorting can work together

### DIFF
--- a/js/custom-nodes-downloader.js
+++ b/js/custom-nodes-downloader.js
@@ -426,6 +426,7 @@ export class CustomNodesInstaller extends ComfyDialog {
 	
 		// Refresh the grid to display sorted data
 		this.createGrid();
+		this.apply_searchbox(this.data);
 	}
 
 	async createGrid() {


### PR DESCRIPTION
Sorry for the oversight in the sorting PR #533.
If a user performed a search and then attempted to sort, the entire node list would incorrectly appear. This commit provides a fix for that.

