### PR TITLE
Add ComfyUI Nich Utils to node list

### DIFF
--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -7243,6 +7243,16 @@
             ],
             "install_type": "unzip",
             "description": "This is a node to convert an image into a CMYK Halftone dot image."
+        },
+        {
+            "author": "nickve28",
+            "title": "ComfyUI Nich Utils",
+            "reference": "https://github.com/nickve28/ComfyUI-Nich-Utils",
+            "files": [
+                "https://github.com/nickve28/ComfyUI-Nich-Utils"
+            ],
+            "install_type": "git-clone",
+            "description": "Several utility nodes for use with ComfyUI."
         }
     ]
 }


### PR DESCRIPTION
Adds ComfyUI Nich Utils to the node list.
Currently contains a single node, to randomize images out of a folder for say, IPadapter or poses (and the option to keep them). With the intention to expand to more utility nodes.