### PR TITLE
Fix the bug of "Unload models"

### DIFF
--- a/js/common.js
+++ b/js/common.js
@@ -154,7 +154,7 @@ export async function free_models() {
 	let res = await api.fetchApi(`/free`, {
 						method: 'POST',
 						headers: { 'Content-Type': 'application/json' },
-						body: '{}'
+						body: '{"unload_models": true}'
 					});
 
 	if(res.status == 200) {


### PR DESCRIPTION
The `/free` API of comfyanonymous/ComfyUI has changed. Commit: https://github.com/comfyanonymous/ComfyUI/commit/6d281b4ff4ad3918a4f3b4ca4a8b547a2ba3bf80

Now, the `/free` API requires `unload_models` and `free_memory` parameters, and the default value is False.

https://github.com/comfyanonymous/ComfyUI/blob/master/server.py#L509


Currently the "Unload Models" button no longer works. It looks like this bug has been around for a long time.

<img width="377" alt="2024-04-24 08 44 36" src="https://github.com/ltdrdata/ComfyUI-Manager/assets/7489176/fd0fbd09-b016-43dc-b2ad-438ac0dbdcef">


This PR updates the `/free` API call and fixes this BUG.