### PR TITLE
Update custom-node-list.json, add Zero Shot Material Transfer

### DIFF
--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -8039,6 +8039,16 @@
             ],
             "install_type": "unzip",
             "description": "This is a node to convert an image into a CMYK Halftone dot image."
+        },
+        {
+            "author": "kealiu",
+            "title": "ComfyUI-ZeroShot-MTrans",
+            "reference": "https://github.com/kealiu/ComfyUI-ZeroShot-MTrans",
+            "files": [
+                "https://github.com/kealiu/ComfyUI-ZeroShot-MTrans"
+            ],
+            "install_type": "git-clone",
+            "description": "An unofficial ComfyUI custom node for Zero-Shot Material Transfer from a Single Image, Given an input image (e.g., a photo of an apple) and a single material exemplar image (e.g., a golden bowl), ZeST can transfer the gold material from the exemplar onto the apple with accurate lighting cues while making everything else consistent."
         }
     ]
 }


### PR DESCRIPTION
Given an input image (e.g., a photo of an apple) and a single material exemplar image (e.g., a golden bowl), ZeST can transfer the gold material from the exemplar onto the apple with accurate lighting cues while making everything else consistent.