### PR TITLE
Update custom-node-list.json

### DIFF
--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -2601,14 +2601,14 @@
             "description": "Nodes: LamaaModelLoad, LamaApply, YamlConfigLoader. a costumer node is realized to remove anything/inpainting anything from a picture by mask inpainting.[w/WARN:This extension includes the entire model, which can result in a very long initial installation time, and there may be some compatibility issues with older dependencies and ComfyUI.]"
         },
         {
-            "author": "thedyze",
+            "author": "audioscavenger",
             "title": "Save Image Extended for ComfyUI",
-            "reference": "https://github.com/thedyze/save-image-extended-comfyui",
+            "reference": "https://github.com/audioscavenger/save-image-extended-comfyui",
             "files": [
-                "https://github.com/thedyze/save-image-extended-comfyui"
+                "https://github.com/audioscavenger/save-image-extended-comfyui"
             ],
             "install_type": "git-clone",
-            "description": "Customize the information saved in file- and folder names. Use the values of sampler parameters as part of file or folder names. Save your positive & negative prompt as entries in a JSON (text) file, in each folder."
+            "description": "Upgrade the Save File node: customize subfolders, file names with checkpoint names, or any sampler attribute your want! [w/NOTE: This node is a fork from @thedyze, since the [a/original repository](https://github.com/thedyze/save-image-extended-comfyui) is no longer maintained. Simply *uninstall* the original version and **REINSTALL** this one.]"
         },
         {
             "author": "SOELexicon",


### PR DESCRIPTION
take over of save-image-extended-comfyui since the author is unresponsive for 6+ months and lots of issues have accumulated. This version is retro-compatible and I added a note just like for efficient-nodes