### PR TITLE
Clarity ai added to custom-node-list.json

### DIFF
--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -43,6 +43,14 @@
             "description": "Nodes: ModelSamplerTonemapNoiseTest, TonemapNoiseWithRescaleCFG, ReferenceOnlySimple, RescaleClassifierFreeGuidanceTest, ModelMergeBlockNumber, ModelMergeSDXL, ModelMergeSDXLTransformers, ModelMergeSDXLDetailedTransformers.[w/NOTE: This is a consolidation of the previously separate custom nodes. Please delete the sampler_tonemap.py, sampler_rescalecfg.py, advanced_model_merging.py, sdxl_model_merging.py, and reference_only.py files installed in custom_nodes before.]"
         },
         {
+            "author": "philz1337x",
+            "title": "✨ Clarity AI - Creative Image Upscaler and Enhancer for ComfyUI",
+            "reference": "https://github.com/philz1337x/ComfyUI-ClarityAI",
+            "files": ["https://github.com/philz1337x/ComfyUI-ClarityAI"],
+            "install_type": "git-clone",
+            "description": "[a/Clarity AI](https://clarityai.cc) is a creative image enhancer and is able to upscale to high resolution. [w/NOTE: This is a Magnific AI alternative for ComfyUI.] \nCreate an API key on [a/ClarityAI.cc/api](https://clarityai.cc/api) and add to environment variable 'CAI_API_KEY'\nAlternatively you can write your API key to file 'cai_platform_key.txt'\nYou can also use and/or override the above by entering your API key in the 'api_key_override' field of the node."
+        },
+        {
             "author": "Stability-AI",
             "title": "Stability API nodes for ComfyUI",
             "reference": "https://github.com/Stability-AI/ComfyUI-SAI_API",


### PR DESCRIPTION
I published an open-source upscaler at https://github.com/philz1337x/clarity-upscaler which runs in a1111 webui. I got many requests to make a ComfyUI version, but I wasn't able to reproduce it with the existing nodes, so I created this API node workaround that gives users the ability to use my app, Clarity AI, which uses the open-source upscaler, in ComfyUI.