### PR TITLE
Update custom-node-list.json

### DIFF
--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -9989,6 +9989,15 @@
             ],
             "install_type": "unzip",
             "description": "This is a node to convert an image into a CMYK Halftone dot image."
+        },
+        {
+          "author": "goktug",
+          "title": "Save Image Plus",
+          "id": "saveimage-plus",
+          "reference": "https://github.com/Goktug/comfyui-saveimage-plus",
+          "files": ["https://github.com/Goktug/comfyui-saveimage-plus"],
+          "install_type": "git-clone",
+          "description": "Save Image Plus is a custom node for ComfyUI that allows you to save images in JPEG and WEBP formats with optional metadata embedding."
         }
     ]
 }

--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -9992,7 +9992,7 @@
         },
         {
           "author": "goktug",
-          "title": "Save Image Plus",
+          "title": "Save Image Plus for ComfyUI",
           "id": "saveimage-plus",
           "reference": "https://github.com/Goktug/comfyui-saveimage-plus",
           "files": ["https://github.com/Goktug/comfyui-saveimage-plus"],


### PR DESCRIPTION
Added a new Save Image Plus custom node for ComfyUI that allows you to save images in JPEG and WEBP formats with optional metadata embedding.

![image](https://github.com/ltdrdata/ComfyUI-Manager/assets/534426/83937a8d-2306-4d90-be90-042a1b9fc4ee)

Repo Link: https://github.com/Goktug/comfyui-saveimage-plus