### PR TITLE
Recommend Impact-Pack instead of Masquerade

### DIFF
--- a/alter-list.json
+++ b/alter-list.json
@@ -28,7 +28,7 @@
      {
        "id":"https://github.com/BadCafeCode/masquerade-nodes-comfyui",
        "tags":"ddetailer",
-       "description": "This extension provides a way to recognize and enhance masks for faces similar to Impact Pack."
+       "description": "This extension is a less feature-rich and well-maintained alternative to Impact Pack, but it has fewer dependencies and may be easier to install on abnormal configurations. The author recommends trying Impact Pack first."
      },
      {
        "id":"https://github.com/BlenderNeko/ComfyUI_Cutoff",

--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -519,7 +519,7 @@
                 "https://github.com/BadCafeCode/masquerade-nodes-comfyui"
             ],
             "install_type": "git-clone",
-            "description": "This is a node pack for ComfyUI, primarily dealing with masks."
+            "description": "This is a low-dependency node pack primarily dealing with masks. The author recommends using Impact-Pack instead (unless you specifically have trouble installing dependencies)."
         },
         {
             "author": "guoyk93",


### PR DESCRIPTION
Update the description of Masquerade Nodes to point people towards Impact Pack instead (unless they are specifically on an abnormal setup where they have trouble installing dependencies).

I've updated the [README of Masquerade Nodes](https://github.com/BadCafeCode/masquerade-nodes-comfyui) to state this as well.