### PR TITLE
feat: Simple reverse proxy for China users

### DIFF
--- a/glob/manager_server.py
+++ b/glob/manager_server.py
@@ -145,6 +145,8 @@ def set_default_ui_mode(mode):
 def set_component_policy(mode):
     core.get_config()['component_policy'] = mode
 
+def set_reverse_proxy_policy(policy):
+    core.get_config()['reverse_proxy_policy'] = policy
 
 def set_double_click_policy(mode):
     core.get_config()['double_click_policy'] = mode
@@ -653,7 +655,6 @@ async def save_snapshot(request):
     except:
         return web.Response(status=400)
 
-
 def unzip_install(files):
     temp_filename = 'manager-temp.zip'
     for url in files:
@@ -777,7 +778,6 @@ def copy_set_active(files, is_disable, js_path_name='.'):
 
     print(f"{action_name} was successful.")
     return True
-
 
 @PromptServer.instance.routes.post("/customnode/install")
 async def install_custom_node(request):
@@ -999,6 +999,8 @@ async def install_model(request):
             model_url = json_data['url']
             if not core.get_config()['model_download_by_agent'] and (
                     model_url.startswith('https://github.com') or model_url.startswith('https://huggingface.co') or model_url.startswith('https://heibox.uni-heidelberg.de')):
+                model_url = core.try_to_use_reverse_proxy(model_url)
+                    
                 model_dir = get_model_dir(json_data)
                 download_url(model_url, model_dir, filename=json_data['filename'])
                 if model_path.endswith('.zip'):
@@ -1090,6 +1092,16 @@ async def component_policy(request):
     else:
         return web.Response(text=core.get_config()['component_policy'], status=200)
 
+    return web.Response(status=200)
+
+@PromptServer.instance.routes.get("/manager/reverse_proxy/policy")
+async def reverse_proxy_policy(request):
+    if "value" in request.rel_url.query:
+        set_reverse_proxy_policy(request.rel_url.query['value'])
+        core.write_config()
+    else:
+        return web.Response(text=core.get_config()['reverse_proxy_policy'], status=200)
+    
     return web.Response(status=200)
 
 

--- a/js/comfyui-manager.js
+++ b/js/comfyui-manager.js
@@ -14,7 +14,7 @@ import { OpenArtShareDialog } from "./comfyui-share-openart.js";
 import { CustomNodesManager } from "./custom-nodes-manager.js";
 import { SnapshotManager } from "./snapshot.js";
 import { ModelInstaller } from "./model-downloader.js";
-import { manager_instance, setManagerInstance, install_via_git_url, install_pip, rebootAPI, free_models, show_message } from "./common.js";
+import { manager_instance, setManagerInstance, install_via_git_url, install_pip, rebootAPI, free_models, show_message, set_reverse_proxy_policy } from "./common.js";
 import { ComponentBuilderDialog, load_components, set_component_policy, getPureName } from "./components-manager.js";
 import { set_double_click_policy } from "./node_fixer.js";
 
@@ -920,6 +920,28 @@ class ManagerMenuDialog extends ComfyDialog {
 			set_component_policy(event.target.value);
 		});
 
+		// reverse-proxy policy
+		let reverse_proxy_combo = document.createElement("select");
+		reverse_proxy_combo.setAttribute("title", "If you are in China, you can use this option to enable reverse-proxy to download custom nodes and models.");
+		reverse_proxy_combo.className = "cm-menu-combo";
+		reverse_proxy_combo.appendChild($el('option', { value: 'none', text: 'Reverse Proxy: None' }, []));
+		reverse_proxy_combo.appendChild($el('option', { value: 'ghproxy-mirror', text: 'Reverse Proxy: GHProxy Mirror to GitHub' }, []));
+		reverse_proxy_combo.appendChild($el('option', { value: 'hf-mirror', text: 'Reverse Proxy: HF-Mirror to HuggingFace' }, []));
+		reverse_proxy_combo.appendChild($el('option', { value: 'both', text: 'Reverse Proxy: Both' }, []));
+
+		api.fetchApi('/manager/reverse_proxy/policy')
+			.then(response => response.text())
+			.then(data => {
+				reverse_proxy_combo.value = data;
+				set_reverse_proxy_policy(data);
+			})
+
+		reverse_proxy_combo.addEventListener('change', function (event) {
+			api.fetchApi(`/manager/reverse_proxy/policy?value=${event.target.value}`);
+			set_reverse_proxy_policy(event.target.value);
+		})
+
+		// double-click policy
 		let dbl_click_policy_combo = document.createElement("select");
 		dbl_click_policy_combo.setAttribute("title", "Sets the behavior when you double-click the title area of a node.");
 		dbl_click_policy_combo.className = "cm-menu-combo";
@@ -970,6 +992,7 @@ class ManagerMenuDialog extends ComfyDialog {
 			default_ui_combo,
 			share_combo,
 			component_policy_combo,
+			reverse_proxy_combo,
 			dbl_click_policy_combo,
 			$el("br", {}, []),
 

--- a/js/common.js
+++ b/js/common.js
@@ -65,6 +65,17 @@ export async function install_pip(packages) {
 	}
 }
 
+let reverse_proxy_policy = "none"
+try {
+	api.fetchApi('/manager/reverse_proxy/policy')
+		.then(response => response.text())
+		.then(data => { reverse_proxy_policy = data; });
+}
+catch {}
+export function set_reverse_proxy_policy(v) {
+	reverse_proxy_policy = v;
+}
+
 export async function install_via_git_url(url, manager_dialog) {
 	if(!url) {
 		return;


### PR DESCRIPTION
It added a option for Chinese, because of slow and unstable connections to GitHub and HuggingFace, it allows users to install custom nodes and models by free reverse proxies, now they are "https://mirror.ghproxy.com" for GitHub and "https://hf-mirror.com" for HuggingFace. You can choose whether using both of them, one of them, or do not use them at all. For others who are in other countries, this option SHOULD KEEP "NONE" in order to avoid possible connection problems.

Options are on the left of the Manager Dialog