### PR TITLE
Allow use of local. subdomain

### DIFF
--- a/glob/manager_server.py
+++ b/glob/manager_server.py
@@ -42,7 +42,7 @@ from comfy.cli_args import args
 import latent_preview
 
 
-is_local_mode = args.listen.startswith('127.')
+is_local_mode = args.listen.startswith('127.') or args.listen.startswith('local.')
 
 
 def is_allowed_security_level(level):


### PR DESCRIPTION
Being able to use --listen local.<domain.name> as a local env instead of 127.0.0.1

example local.comfy.org