### PR TITLE
Update description for JNodes

### DIFF
--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -5899,7 +5899,7 @@
                 "https://github.com/JaredTherriault/ComfyUI-JNodes"
             ],
             "install_type": "git-clone",
-            "description": "python and web UX improvements for ComfyUI.\n[w/'DynamicPrompts.js' and 'EditAttention.js' from the core, along with 'ImageFeed.js' and 'favicon.js' from the custom scripts of pythongosssss, are not compatible. Therefore, manual deletion of these files is required to use this web extension.]"
+            "description": "python and web UX improvements for ComfyUI: Lora/Embedding picker, web extension manager (enable/disable any extension without disabling python nodes), control any parameter with text prompts, image and video viewer, metadata viewer, token counter, comments in prompts, font control, and more! \n[w/'ImageFeed.js' from the custom scripts of pythongosssss is not compatible with this suite's ImageDrawer feature. Additionally, 'DynamicPrompts.js' and 'EditAttention.js' from the core, along with 'favicon.js' from the custom scripts of pythongosssss, are incompatible with advanced features of the suite. Please use the JNodes Extension Management setting in Settings > JNodes > Extension Management to disable these extensions by unchecking them to use the full functionality of the suite.]"
         },
         {
             "author": "prozacgod",


### PR DESCRIPTION
- Updated the main description to reflect the current repository
- Made the warning clearer (that only ImageFeed from pythongosssss actually needs to be disabled and let users know it can be disabled using the JNodes web features without needing to delete any files manually)