### PR TITLE
Add support for SSH-style git repo addresses

### DIFF
--- a/cm-cli.py
+++ b/cm-cli.py
@@ -201,7 +201,7 @@ cm_ctx = Ctx()
 
 
 def install_node(node_name, is_all=False, cnt_msg=''):
-    if '://' in node_name:
+    if core.is_valid_url(node_name):
         # install via urls
         res = core.gitclone_install([node_name])
         if not res:

--- a/glob/manager_core.py
+++ b/glob/manager_core.py
@@ -515,10 +515,16 @@ class GitProgress(RemoteProgress):
 
 def is_valid_url(url):
     try:
+        # Check for HTTP/HTTPS URL format
         result = urlparse(url)
-        return all([result.scheme, result.netloc])
-    except ValueError:
-        return False
+        if all([result.scheme, result.netloc]):
+            return True
+    finally:
+        # Check for SSH git URL format
+        pattern = re.compile(r"^(.+@|ssh:\/\/).+:.+$")
+        if pattern.match(url):
+            return True
+    return False
 
 
 def gitclone_install(files, instant_execution=False, msg_prefix=''):

--- a/js/common.js
+++ b/js/common.js
@@ -34,8 +34,9 @@ function isValidURL(url) {
 	if(url.includes('&'))
 		return false;
 
-	const pattern = /^(https?|ftp):\/\/[^\s/$.?#].[^\s]*$/;
-	return pattern.test(url);
+	const http_pattern = /^(https?|ftp):\/\/[^\s$?#]+$/;
+	const ssh_pattern = /^(.+@|ssh:\/\/).+:.+$/;
+	return http_pattern.test(url) || ssh_pattern.test(url);
 }
 
 export async function install_pip(packages) {


### PR DESCRIPTION
This allows nodes to be pulled from git repositories that:
1. Require authentication
2. Are located on a computer that does not have any special software beyond an SSH server to serve up git repos
3. Are hosted on sites that exclusively allow SSH access

I have also cleaned up the JavaScript regex for identifying valid HTTP addresses. Due to an unescaped '.' and the lack of a count on the first group, it wasn't doing a whole lot anyway -- just checking that the very first character wasn't invalid.