### PR TITLE
Update custom-node-list.json for FW nodes

### DIFF
--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -11671,14 +11671,14 @@
         },
         {
             "author": "fearnworks",
-            "title": "Fearnworks Custom Nodes",
+            "title": "Fearnworks Nodes",
             "id": "fearnworks",
             "reference": "https://github.com/fearnworks/ComfyUI_FearnworksNodes",
             "files": [
-                "https://github.com/fearnworks/ComfyUI_FearnworksNodes/raw/main/fw_nodes.py"
+                "https://github.com/fearnworks/ComfyUI_FearnworksNodes"
             ],
-            "install_type": "copy",
-            "description": "A collection of ComfyUI nodes. These nodes are tailored for specific tasks, such as counting files in directories and sorting text segments based on token counts. Currently this is only tested on SDXL 1.0 models. An additional swich is needed to hand 1.x"
+            "install_type": "git-clone",
+            "description": "This extension provides various nodes to support multimodal workflows."
         },
         {
             "author": "LZC",

--- a/extension-node-map.json
+++ b/extension-node-map.json
@@ -9087,7 +9087,7 @@
             "title_aux": "ComfyUI-Showrunner-Utils"
         }
     ],
-    "https://github.com/fearnworks/ComfyUI_FearnworksNodes/raw/main/fw_nodes.py": [
+    "https://github.com/fearnworks/ComfyUI_FearnworksNodes": [
         [
             "Count Files in Directory (FW)",
             "Count Tokens (FW)",
@@ -9095,7 +9095,7 @@
             "Trim To Tokens (FW)"
         ],
         {
-            "title_aux": "Fearnworks Custom Nodes"
+            "title_aux": "Fearnworks Nodes"
         }
     ],
     "https://github.com/fexli/fexli-util-node-comfyui": [


### PR DESCRIPTION
Hello, I am the author of this library, but did not add it to this list. This update syncs up the manager listing with the current implementation and actual comfyui registry info so it can install succesfully from the ui. 

I tried to test the update by modifying the custom-node-list from my local install, but it still seems to be trying to grab the old file. If there are additional changes needed or a way to test let me know and I would be happy to resolve! 