### PR TITLE
added support for `--no-deps` option to node install and reinstall

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 __pycache__/
 .idea/
 .vscode/
+.history/
+*.code-workspace
 .tmp
 .cache
 config.ini

--- a/cm-cli.py
+++ b/cm-cli.py
@@ -80,6 +80,7 @@ read_downgrade_blacklist()  # This is a preparation step for manager_core
 class Ctx:
     def __init__(self):
         self.channel = 'default'
+        self.no_deps = False
         self.mode = 'cache'
 
     def set_channel_mode(self, channel, mode):
@@ -100,6 +101,9 @@ class Ctx:
         asyncio.run(unified_manager.reload(cache_mode=self.mode == 'cache'))
         asyncio.run(unified_manager.load_nightly(self.channel, self.mode))
 
+    def set_no_deps(self, no_deps):
+        self.no_deps = no_deps
+
 
 channel_ctx = Ctx()
 
@@ -107,7 +111,7 @@ channel_ctx = Ctx()
 def install_node(node_spec_str, is_all=False, cnt_msg=''):
     if core.is_valid_url(node_spec_str):
         # install via urls
-        res = asyncio.run(core.gitclone_install(node_spec_str))
+        res = asyncio.run(core.gitclone_install(node_spec_str, no_deps=channel_ctx.no_deps))
         if not res.result:
             print(res.msg)
             print(f"[bold red]ERROR: An error occurred while installing '{node_spec_str}'.[/bold red]")
@@ -125,7 +129,7 @@ def install_node(node_spec_str, is_all=False, cnt_msg=''):
         if not is_specified:
             version_spec = None
 
-        res = asyncio.run(unified_manager.install_by_id(node_name, version_spec, channel_ctx.channel, channel_ctx.mode, instant_execution=True))
+        res = asyncio.run(unified_manager.install_by_id(node_name, version_spec, channel_ctx.channel, channel_ctx.mode, instant_execution=True, no_deps=channel_ctx.no_deps))
 
         if res.action == 'skip':
             print(f"{cnt_msg} [   SKIP  ] {node_name:50} => Already installed")
@@ -171,7 +175,7 @@ def fix_node(node_spec_str, is_all=False, cnt_msg=''):
     node_name, version_spec, _ = node_spec
 
     print(f"{cnt_msg} [   FIXING  ]: {node_name:50}[{version_spec}]")
-    res = unified_manager.unified_fix(node_name, version_spec)
+    res = unified_manager.unified_fix(node_name, version_spec, no_deps=channel_ctx.no_deps)
 
     if not res.result:
         print(f"ERROR: f{res.msg}")
@@ -211,7 +215,7 @@ def update_node(node_spec_str, is_all=False, cnt_msg=''):
 
     node_name, version_spec, _ = node_spec
 
-    res = unified_manager.unified_update(node_name, version_spec, return_postinstall=True)
+    res = unified_manager.unified_update(node_name, version_spec, no_deps=channel_ctx.no_deps, return_postinstall=True)
 
     if not res.result:
         print(f"ERROR: An error occurred while updating '{node_name}'.")
@@ -549,9 +553,17 @@ def install(
         mode: str = typer.Option(
             None,
             help="[remote|local|cache]"
-        )
+        ),
+        no_deps: Annotated[
+            Optional[bool],
+            typer.Option(
+                show_default=False,
+                help="Use new fast dependency installer",
+            ),
+        ] = False,
 ):
     channel_ctx.set_channel_mode(channel, mode)
+    channel_ctx.set_no_deps(no_deps)
     for_each_nodes(nodes, act=install_node)
 
 
@@ -571,8 +583,16 @@ def reinstall(
             None,
             help="[remote|local|cache]"
         ),
+        no_deps: Annotated[
+            Optional[bool],
+            typer.Option(
+                show_default=False,
+                help="Use new fast dependency installer",
+            ),
+        ] = False,
 ):
     channel_ctx.set_channel_mode(channel, mode)
+    channel_ctx.set_no_deps(no_deps)
     for_each_nodes(nodes, act=reinstall_node)
 
 

--- a/cm-cli.py
+++ b/cm-cli.py
@@ -557,8 +557,9 @@ def install(
         no_deps: Annotated[
             Optional[bool],
             typer.Option(
+                "--no-deps",
                 show_default=False,
-                help="Use new fast dependency installer",
+                help="Skip installing any Python dependencies",
             ),
         ] = False,
 ):
@@ -586,8 +587,9 @@ def reinstall(
         no_deps: Annotated[
             Optional[bool],
             typer.Option(
+                "--no-deps",
                 show_default=False,
-                help="Use new fast dependency installer",
+                help="Skip installing any Python dependencies",
             ),
         ] = False,
 ):

--- a/glob/manager_core.py
+++ b/glob/manager_core.py
@@ -677,7 +677,7 @@ class UnifiedManager:
         except:
             return version.parse("0.0.0")
 
-    def execute_install_script(self, url, repo_path, lazy_mode=False, instant_execution=False):
+    def execute_install_script(self, url, repo_path, instant_execution=False, lazy_mode=False, no_deps=False):
         install_script_path = os.path.join(repo_path, "install.py")
         requirements_path = os.path.join(repo_path, "requirements.txt")
 
@@ -685,7 +685,7 @@ class UnifiedManager:
             install_cmd = ["#LAZY-INSTALL-SCRIPT", sys.executable]
             return try_install_script(url, repo_path, install_cmd)
         else:
-            if os.path.exists(requirements_path):
+            if os.path.exists(requirements_path) and not no_deps:
                 print("Install: pip packages")
                 with open(requirements_path, "r") as requirements_file:
                     for line in requirements_file:
@@ -704,7 +704,7 @@ class UnifiedManager:
 
         return True
 
-    def unified_fix(self, node_id, version_spec, instant_execution=False):
+    def unified_fix(self, node_id, version_spec, instant_execution=False, no_deps=False):
         """
         fix dependencies
         """
@@ -715,11 +715,11 @@ class UnifiedManager:
         if info is None or not os.path.exists(info[1]):
             return result.fail(f'not found: {node_id}@{version_spec}')
 
-        self.execute_install_script(node_id, info[1], instant_execution=instant_execution)
+        self.execute_install_script(node_id, info[1], instant_execution=instant_execution, no_deps=no_deps)
 
         return result
 
-    def cnr_switch_version(self, node_id, version_spec=None, instant_execution=False, return_postinstall=False):
+    def cnr_switch_version(self, node_id, version_spec=None, instant_execution=False, no_deps=False, return_postinstall=False):
         """
         switch between cnr version
         """
@@ -783,7 +783,7 @@ class UnifiedManager:
         result.target = version_spec
 
         def postinstall():
-            res = self.execute_install_script(f"{node_id}@{version_spec}", new_install_path, instant_execution=instant_execution)
+            res = self.execute_install_script(f"{node_id}@{version_spec}", new_install_path, instant_execution=instant_execution, no_deps=no_deps)
             return res
 
         if return_postinstall:
@@ -976,7 +976,7 @@ class UnifiedManager:
 
         return result
 
-    def cnr_install(self, node_id, version_spec=None, instant_execution=False, return_postinstall=False):
+    def cnr_install(self, node_id, version_spec=None, instant_execution=False, no_deps=False, return_postinstall=False):
         result = ManagedResult('install-cnr')
 
         node_info = cnr_utils.install_node(node_id, version_spec)
@@ -1013,7 +1013,7 @@ class UnifiedManager:
         result.target = version_spec
 
         def postinstall():
-            return self.execute_install_script(node_id, install_path, instant_execution=instant_execution)
+            return self.execute_install_script(node_id, install_path, instant_execution=instant_execution, no_deps=no_deps)
 
         if return_postinstall:
             return result.with_postinstall(postinstall)
@@ -1023,7 +1023,7 @@ class UnifiedManager:
 
         return result
 
-    def repo_install(self, url, repo_path, instant_execution=False, return_postinstall=False):
+    def repo_install(self, url, repo_path, instant_execution=False, no_deps=False, return_postinstall=False):
         result = ManagedResult('install-git')
         result.append(url)
 
@@ -1046,7 +1046,7 @@ class UnifiedManager:
                 repo.close()
 
             def postinstall():
-                return self.execute_install_script(url, repo_path, instant_execution=instant_execution)
+                return self.execute_install_script(url, repo_path, instant_execution=instant_execution, no_deps=no_deps)
 
             if return_postinstall:
                 return result.with_postinstall(postinstall)
@@ -1060,7 +1060,7 @@ class UnifiedManager:
         print("Installation was successful.")
         return result
 
-    def repo_update(self, repo_path, instant_execution=False, return_postinstall=False):
+    def repo_update(self, repo_path, instant_execution=False, no_deps=False, return_postinstall=False):
         result = ManagedResult('update-git')
 
         if not os.path.exists(os.path.join(repo_path, '.git')):
@@ -1109,7 +1109,7 @@ class UnifiedManager:
                 url = "unknown repo"
 
             def postinstall():
-                return self.execute_install_script(url, repo_path, instant_execution=instant_execution)
+                return self.execute_install_script(url, repo_path, instant_execution=instant_execution, no_deps=no_deps)
 
             if return_postinstall:
                 return result.with_postinstall(postinstall)
@@ -1121,7 +1121,7 @@ class UnifiedManager:
         else:
             return ManagedResult('skip').with_msg('Up to date')
 
-    def unified_update(self, node_id, version_spec=None, instant_execution=False, return_postinstall=False):
+    def unified_update(self, node_id, version_spec=None, instant_execution=False, no_deps=False, return_postinstall=False):
         if version_spec is None:
             version_spec = self.resolve_unspecified_version(node_id, guess_mode='active')
 
@@ -1129,13 +1129,13 @@ class UnifiedManager:
             return ManagedResult('update').fail(f'Update not available: {node_id}@{version_spec}')
 
         if version_spec == 'nightly':
-            return self.repo_update(self.active_nodes[node_id][1], instant_execution=instant_execution, return_postinstall=return_postinstall).with_target('nightly')
+            return self.repo_update(self.active_nodes[node_id][1], instant_execution=instant_execution, no_deps=no_deps, return_postinstall=return_postinstall).with_target('nightly')
         elif version_spec == 'unknown':
-            return self.repo_update(self.unknown_active_nodes[node_id][1], instant_execution=instant_execution, return_postinstall=return_postinstall).with_target('unknown')
+            return self.repo_update(self.unknown_active_nodes[node_id][1], instant_execution=instant_execution, no_deps=no_deps, return_postinstall=return_postinstall).with_target('unknown')
         else:
-            return self.cnr_switch_version(node_id, instant_execution=instant_execution, return_postinstall=return_postinstall)
+            return self.cnr_switch_version(node_id, instant_execution=instant_execution, no_deps=no_deps, return_postinstall=return_postinstall)
 
-    async def install_by_id(self, node_id, version_spec=None, channel=None, mode=None, instant_execution=False, return_postinstall=False):
+    async def install_by_id(self, node_id, version_spec=None, channel=None, mode=None, instant_execution=False, no_deps=False, return_postinstall=False):
         """
         priority if version_spec == None
         1. CNR latest
@@ -1175,7 +1175,7 @@ class UnifiedManager:
                     self.unified_disable(node_id, False)
 
             to_path = os.path.abspath(os.path.join(custom_nodes_path, f"{node_id}@{version_spec.replace('.', '_')}"))
-            res = self.repo_install(repo_url, to_path, instant_execution=instant_execution, return_postinstall=return_postinstall)
+            res = self.repo_install(repo_url, to_path, instant_execution=instant_execution, no_deps=no_deps, return_postinstall=return_postinstall)
             if res.result:
                 if version_spec == 'unknown':
                     self.unknown_active_nodes[node_id] = to_path
@@ -1195,12 +1195,12 @@ class UnifiedManager:
         if self.is_disabled(node_id, "cnr"):
             # enable and switch version if cnr is disabled (not specified version)
             self.unified_enable(node_id, "cnr")
-            return self.cnr_switch_version(node_id, version_spec, return_postinstall=return_postinstall)
+            return self.cnr_switch_version(node_id, version_spec, no_deps=no_deps, return_postinstall=return_postinstall)
 
         if self.is_enabled(node_id, "cnr"):
-            return self.cnr_switch_version(node_id, version_spec, return_postinstall=return_postinstall)
+            return self.cnr_switch_version(node_id, version_spec, no_deps=no_deps, return_postinstall=return_postinstall)
 
-        res = self.cnr_install(node_id, version_spec, instant_execution=instant_execution, return_postinstall=return_postinstall)
+        res = self.cnr_install(node_id, version_spec, instant_execution=instant_execution, no_deps=no_deps, return_postinstall=return_postinstall)
         if res.result:
             self.active_nodes[node_id] = version_spec, res.to_path
 


### PR DESCRIPTION
Adds support for a `no-deps` option to the `node install` and `node reinstall` commands. Not only is this useful to have in general, but it's needed to support the new `--fast-deps` behavior (unified/much faster python dependency installs) in comfy-cli.

Two unresolved questions:
- What commands aside from install/reinstall should also get a `no-deps` option? I added plumbing for  `no-deps` such that it should be respected for any command that sets `cm_ctx.no_deps = True`, so it should now be easy to add to any command
- I noticed that adjacent to `requirements.txt` support, there is also support for running some kind of generic `<node_root>/install.py` installation script. Should this installation script support also be disabled by the `no-deps` option? For now I've left it untouched