### PR TITLE
Update security check for llmvision

### DIFF
--- a/glob/security_check.py
+++ b/glob/security_check.py
@@ -12,7 +12,7 @@ def security_check():
     guide = {
         "ComfyUI_LLMVISION": """
 0.Remove ComfyUI\\custom_nodes\\ComfyUI_LLMVISION.
-1.Remove pip packages: openai-1.16.3.dist-info, anthropic-0.21.4.dist-info, openai-1.30.2.dist-info, anthropic-0.26.1.dist-info, %LocalAppData%\\rundll64.exe
+1.Remove pip packages: openai-1.16.3.dist-info, anthropic-0.21.4.dist-info, openai-1.30.2.dist-info, anthropic-0.21.5.dist-info, anthropic-0.26.1.dist-info, %LocalAppData%\\rundll64.exe
   (For portable versions, it is recommended to reinstall. If you are using a venv, it is advised to recreate the venv.)
 2.Remove these files in your system: lib/browser/admin.py, Cadmino.py, Fadmino.py, VISION-D.exe, BeamNG.UI.exe
 3.Check your Windows registry for the key listed above and remove it.
@@ -44,6 +44,18 @@ Detailed information: https://old.reddit.com/r/comfyui/comments/1dbls5n/psa_if_y
     installed_pips = subprocess.check_output([sys.executable, '-m', "pip", "freeze"], text=True)
 
     detected = set()
+    try:
+        anthropic_info = subprocess.check_output([sys.executable, '-m', "pip", "show", "anthropic"], text=True, stderr=subprocess.DEVNULL)
+        anthropic_reqs = [x for x in anthropic_info.split('\n') if x.startswith("Requires")][0].split(': ')[1]
+        if "pycrypto" in anthropic_reqs:
+            location = [x for x in anthropic_info.split('\n') if x.startswith("Location")][0].split(': ')[1]
+            for fi in os.listdir(location):
+                if fi.startswith("anthropic"):
+                    guide["ComfyUI_LLMVISION"] = f"\n0.Remove {os.path.join(location, fi)}" + guide["ComfyUI_LLMVISION"]
+                    detected.add("ComfyUI_LLMVISION")
+    except subprocess.CalledProcessError:
+        pass
+
     for k, v in node_blacklist.items():
         if os.path.exists(os.path.join(custom_nodes_path, k)):
             print(f"[SECURITY ALERT] custom node '{k}' is dangerous.")


### PR DESCRIPTION
The reddit post about ComfyUI_LLMVISION and the security check message here don't mention anthropic version `0.21.5`. However, in early June the repo was shipping `0.21.5` with the malicious code ([web archive to wheel](https://web.archive.org/web/20240609140457/https://raw.githubusercontent.com/AppleBotzz/Backup-Anthropic-Builds/main/anthropic-0.21.3-py3-none-any.whl))

The wheel says `0.21.3` but this is what it unpacks to:

![screenshot](https://github.com/user-attachments/assets/bc97a317-7e78-42a1-bd6c-a3232d184de3)

You can see one of the distinguishing features of the mailicious package is that it requires `pycrypto`. So I added a check for anthropic packages which require pycrypto to the security check.