### PR TITLE
 feat: mapping clip and checkpoint to model path

### DIFF
--- a/glob/manager_server.py
+++ b/glob/manager_server.py
@@ -249,8 +249,12 @@ def get_model_dir(data):
         model_type = data['type']
         if model_type == "checkpoints":
             base_model = folder_paths.folder_names_and_paths["checkpoints"][0][0]
+        elif model_type == "checkpoint":
+            base_model = folder_paths.folder_names_and_paths["checkpoints"][0][0]
         elif model_type == "unclip":
             base_model = folder_paths.folder_names_and_paths["checkpoints"][0][0]
+        elif model_type == "clip":
+            base_model = folder_paths.folder_names_and_paths["clip"][0][0]
         elif model_type == "VAE":
             base_model = folder_paths.folder_names_and_paths["vae"][0][0]
         elif model_type == "lora":


### PR DESCRIPTION
Hi Ltdrdata,

I seen some change in model-list.json:
   the type "checkpoints" was changed to "checkpoint", but in the glob.manager_server.get_model_dir without this mapping
   and comfyanonymous/clip_l is default path, clip is also without mapping

And I seen the defualt path is **etc**, not in ComfyUI/models/etc. maybe use `os.path.join(folder_paths.models_dir, "etc")` is better?