### PR TITLE
New node: LatentGC

### DIFF
--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -13159,6 +13159,6 @@
             ],
             "install_type": "git-clone",
             "description": "Simple latent-passthrough node for running a full VRAM cleanup between workflow stages."
-        },
+        }
     ]
 }

--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -13148,6 +13148,17 @@
             ],
             "install_type": "unzip",
             "description": "This is a node to convert an image into a CMYK Halftone dot image."
-        }
+        },
+        {
+            "author": "Raapys",
+            "title": "LatentGC Aggressive",
+            "id": "latentgcaggressive",
+            "reference": "https://github.com/Raapys/ComfyUI-LatentGC_Aggressive",
+            "files": [
+                "https://github.com/Raapys/ComfyUI-LatentGC_Aggressive"
+            ],
+            "install_type": "git-clone",
+            "description": "Simple latent-passthrough node for running a full VRAM cleanup between workflow stages."
+        },
     ]
 }


### PR DESCRIPTION
This adds a new node that allows the user to clean VRAM between workflow stages. There was already an alternative called LatentGarbageCollector (https://github.com/ntdviet/comfyui-ext), but this is a more aggressive version that also unloads models and which, in my workflows, allows for setups that would otherwise grind to a halt due to running out of VRAM. 