### PR TITLE
Handle comments on the same line as package name

### DIFF
--- a/glob/manager_core.py
+++ b/glob/manager_core.py
@@ -410,6 +410,14 @@ def execute_install_script(url, repo_path, lazy_mode=False, instant_execution=Fa
             print("Install: pip packages")
             with open(requirements_path, "r") as requirements_file:
                 for line in requirements_file:
+                    #handle comments
+                    if '#' in line:
+                        if line.strip()[0] == '#':
+                            print("Line is comment...skipping")
+                            continue
+                        else:
+                            line = line.split('#')[0].strip()
+
                     package_name = remap_pip_package(line.strip())
 
                     if package_name and not package_name.startswith('#'):


### PR DESCRIPTION
cm-cli.py was failing when installing requirements if there were comments on the same line as the package name.
Example of failing line below:
pillow>=10.0.1      # Current version has not be validated

Added a test to see if '#' exists in a line from requirements.txt if so, split on the '#' character and return the [0] value in the split as the line.



