### PR TITLE
Faster plugins installation & less space taken

### DIFF
--- a/glob/manager_core.py
+++ b/glob/manager_core.py
@@ -563,11 +563,11 @@ def gitclone_install(files, instant_execution=False, msg_prefix=''):
 
             # Clone the repository from the remote URL
             if not instant_execution and platform.system() == 'Windows':
-                res = manager_funcs.run_script([sys.executable, git_script_path, "--clone", custom_nodes_path, url], cwd=custom_nodes_path)
+                res = manager_funcs.run_script([sys.executable, git_script_path, "--clone --depth=1 --single-branch --recurse-submodules", custom_nodes_path, url], cwd=custom_nodes_path)
                 if res != 0:
                     return False
             else:
-                repo = git.Repo.clone_from(url, repo_path, recursive=True, progress=GitProgress())
+                repo = git.Repo.clone_from(url, repo_path,  multi_options = ["--depth=1", "--single-branch", "--recurse-submodules"], progress=GitProgress())
                 repo.git.clear_cache()
                 repo.close()
 

--- a/scanner.py
+++ b/scanner.py
@@ -259,7 +259,7 @@ def clone_or_pull_git_repository(git_url):
             print(f"Pulling {repo_name} failed: {e}")
     else:
         try:
-            Repo.clone_from(git_url, repo_dir, recursive=True)
+            Repo.clone_from(git_url, repo_dir, multi_options = ["--depth=1", "--single-branch" "--recurse-submodules"])
             print(f"Cloning {repo_name}...")
         except Exception as e:
             print(f"Cloning {repo_name} failed: {e}")

--- a/scanner.py
+++ b/scanner.py
@@ -259,7 +259,7 @@ def clone_or_pull_git_repository(git_url):
             print(f"Pulling {repo_name} failed: {e}")
     else:
         try:
-            Repo.clone_from(git_url, repo_dir, multi_options = ["--depth=1", "--single-branch" "--recurse-submodules"])
+            Repo.clone_from(git_url, repo_dir, multi_options = ["--depth=1", "--single-branch", "--recurse-submodules"])
             print(f"Cloning {repo_name}...")
         except Exception as e:
             print(f"Cloning {repo_name} failed: {e}")


### PR DESCRIPTION
Closes https://github.com/ltdrdata/ComfyUI-Manager/issues/891
This change allows ComfyUI-Manager to only clone the latest commit from the relevant branch, so that we do not end up with some extensions taking up GB on disk.
Yes, this is a real issue :(. 