### PR TITLE
Add TripoSR Texture Generator node

### DIFF
--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -1959,17 +1959,6 @@
             "description": "A powerful anti-burn allowing much higher CFG scales for latent diffusion models (for ComfyUI)"
         },
         {
-            "author": "Extraltodeus",
-            "title": "DistanceSampler",
-            "id": "distancesampler",
-            "reference": "https://github.com/Extraltodeus/DistanceSampler",
-            "files": [
-                "https://github.com/Extraltodeus/Skimmed_CFG"
-            ],
-            "install_type": "git-clone",
-            "description": "Heuristic modification of the Heun sampler using a custom function based on normalized distances. For ComfyUI."
-        },
-        {
             "author": "JPS",
             "title": "JPS Custom Nodes for ComfyUI",
             "id": "jps-nodes",
@@ -3615,7 +3604,7 @@
                 "https://github.com/GMapeSplat/ComfyUI_ezXY"
             ],
             "install_type": "git-clone",
-            "description": "Extensions/Patches: Enables linking float and integer inputs and ouputs. Values are automatically cast to the correct type and clamped to the correct range. Works with both builtin and custom nodes.[w/NOTE: This repo patches ComfyUI's validate_inputs and map_node_over_list functions while running. May break depending on your version of ComfyUI. Can be deactivated in config.yaml.]Nodes: A collection of nodes for facilitating the generation of XY plots. Capable of plotting changes over most primitive values.[w/Does not work with current version of Comfyui]"
+            "description": "Extensions/Patches: Enables linking float and integer inputs and ouputs. Values are automatically cast to the correct type and clamped to the correct range. Works with both builtin and custom nodes.[w/NOTE: This repo patches ComfyUI's validate_inputs and map_node_over_list functions while running. May break depending on your version of ComfyUI. Can be deactivated in config.yaml.]Nodes: A collection of nodes for facilitating the generation of XY plots. Capable of plotting changes over most primitive values."
         },
         {
             "author": "kinfolk0117",
@@ -9272,7 +9261,7 @@
                 "https://github.com/smthemex/ComfyUI_Stable_Makeup"
             ],
             "install_type": "git-clone",
-            "description": "You can apply makeup to the characters in comfyui\nStable_Makeup From: [a/Stable_Makeup](https://github.com/Xiaojiu-z/Stable-Makeup)"
+            "description": "You can apply makeup to the characters in comfyui"
         },
         {
             "author": "smthemex",
@@ -9360,7 +9349,7 @@
                 "https://github.com/smthemex/ComfyUI_MS_Diffusion"
             ],
             "install_type": "git-clone",
-            "description": "you can make story in comfyUI using MS-diffusion"
+            "description": "You can using MS-diffusion make story in comfyUI."
         },
         {
             "author": "smthemex",
@@ -9460,17 +9449,6 @@
             ],
             "install_type": "git-clone",
             "description": "MooER is an LLM-based Speech Recognition and Translation Model from Moore Threads.You can use MooER when install ComfyUI_MooER node"
-        },
-        {
-            "author": "smthemex",
-            "title": "ComfyUI_CSGO_Wrapper",
-            "id": "comfyui_csgo_wrapper",
-            "reference": "https://github.com/smthemex/ComfyUI_CSGO_Wrapper",
-            "files": [
-                "https://github.com/smthemex/ComfyUI_CSGO_Wrapper"
-            ],
-            "install_type": "git-clone",
-            "description": "using InstantX's CSGO in comfyUI for style"
         },
         {
             "author": "choey",
@@ -9821,9 +9799,9 @@
             "author": "DarKDinDoN",
             "title": "ComfyUI Checkpoint Automatic Config",
             "id": "checkpoint-autoconfig",
-            "reference": "https://github.com/mech-tools/comfyui-checkpoint-automatic-config",
+            "reference": "https://github.com/DarKDinDoN/comfyui-checkpoint-automatic-config",
             "files": [
-                "https://github.com/mech-tools/comfyui-checkpoint-automatic-config"
+                "https://github.com/DarKDinDoN/comfyui-checkpoint-automatic-config"
             ],
             "install_type": "git-clone",
             "description": "This node was designed to help with checkpoint configuration. Fee free to add new checkpoint configurations!"
@@ -12247,7 +12225,7 @@
                 "https://github.com/miaoshouai/ComfyUI-Miaoshouai-Tagger"
             ],
             "install_type": "git-clone",
-            "description": "Nodes to use Florence2 VLM for image tagging and captioning"
+            "description": "A node helps with image tagging and caption based on Florence-2-base-PromptGen model."
         },
         {
             "author": "Patricio Gonzalez Vivo",
@@ -12908,7 +12886,7 @@
                 "https://github.com/emojiiii/ComfyUI_Emojiiii_Custom_Nodes"
             ],
             "install_type": "git-clone",
-            "description": "Nodes:MultiTextEncode, KolorsMultiTextEncode, Caption, BatchImageProcessor"
+            "description": "Nodes:MultiTextEncode, KolorsMultiTextEncode"
         },
         {
             "author": "aonekoss",
@@ -13258,7 +13236,7 @@
                 "https://github.com/Pheat-AI/Remade_nodes"
             ],
             "install_type": "git-clone",
-            "description": "Nodes:Batch Image Blend by Mask, Batch Enlarged Overlay, Batch Image Overlay, Remove Black Pixels to Transparent"
+            "description": "Nodes:Batch Image Blend by Mask"
         },
         {
             "author": "OgreLemonSoup",
@@ -13753,7 +13731,7 @@
                 "https://github.com/Steudio/ComfyUI_Steudio"
             ],
             "install_type": "git-clone",
-            "description": "Nodes: Make_Tile_Calc, Make_Tiles, Unmake_Tiles, Make_Size, Make_Size_Latent"
+            "description": "Nodes: TileSplit (Dynamic), TileMerge (Dynamic)"
         },
         {
             "author": "Assistant",
@@ -13763,7 +13741,7 @@
                 "https://github.com/NakamuraShippo/ComfyUI-PromptList"
             ],
             "install_type": "git-clone",
-            "description": "Custom node to manage prompts in YAML format."
+            "description": "Custom node for managing prompts with CSV integration"
         },
         {
             "author": "nux1111",
@@ -14025,17 +14003,6 @@
             "description": "This is a custom node to convert png images into color ASCII art. As noted below, multiple font sizes are used in the specification. The resolution of the generated file is set to be the same as the input image."
         },
         {
-            "author": "Shiba-2-shiba",
-            "title": "ComfyUI_DiffusionModel_fp8_converter",
-            "id": "fp8-converter",
-            "reference": "https://github.com/Shiba-2-shiba/ComfyUI_DiffusionModel_fp8_converter",
-            "files": [
-                "https://github.com/Shiba-2-shiba/ComfyUI_DiffusionModel_fp8_converter"
-            ],
-            "install_type": "git-clone",
-            "description": "This is a custom node to convert only the Diffusion model part or CLIP model part to fp8 in ComfyUI.\nVAE fp8 conversion is not supported.\nThe advantage of this node is that you do not need to separate unet/clip/vae in advance when converting to fp8, but can use the safetenros files that ComfyUI provides."
-        },
-        {
             "author": "Bao Pham",
             "title": "ComfyUI-LyraVSIH",
             "id": "lyra-vsih",
@@ -14109,112 +14076,6 @@
             "install_type": "git-clone",
             "description": "Implementation of color transfer using KMeans algorithm"
         },
-        {
-            "author": "Phando",
-            "title": "ComfyUI-PhandoNodes",
-            "reference": "https://github.com/Phando/ComfyUI-PhandoNodes",
-            "files": [
-                "https://github.com/Phando/ComfyUI-PhandoNodes"
-            ],
-            "install_type": "git-clone",
-            "description": "A collection of nodes to help streamline your ComfyUI workflows"
-        },
-        {
-            "author": "geocine",
-            "title": "geocine-comfyui",
-            "reference": "https://github.com/geocine/geocine-comfyui",
-            "files": [
-                "https://github.com/geocine/geocine-comfyui"
-            ],
-            "install_type": "git-clone",
-            "description": "NODES:Image Selector (geocine), Image Scale (geocine)"
-        },
-        {
-            "author": "SeanScripts",
-            "title": "ComfyUI-Unload-Model",
-            "reference": "https://github.com/SeanScripts/ComfyUI-Unload-Model",
-            "files": [
-                "https://github.com/SeanScripts/ComfyUI-Unload-Model"
-            ],
-            "install_type": "git-clone",
-            "description": "For unloading a model or all models, using the memory management that is already present in ComfyUI. Copied from [a/https://github.com/willblaschko/ComfyUI-Unload-Models](https://github.com/willblaschko/ComfyUI-Unload-Models) but without the unnecessary extra stuff."
-        },
-        {
-            "author": "ExterminanzHS",
-            "title": "Gecco Discord Autosend",
-            "reference": "https://github.com/ExterminanzHS/Gecco-Discord-Autosend",
-            "files": [
-                "https://github.com/ExterminanzHS/Gecco-Discord-Autosend"
-            ],
-            "install_type": "git-clone",
-            "description": "Custom nodes for ComfyUI to automatically send generated images to Discord channels."
-        },
-        {
-            "author": "Hugo",
-            "title": "ComfyUI-BiRefNet-Hugo",
-            "id": "BiRefNet",
-            "reference": "https://github.com/MoonHugo/ComfyUI-BiRefNet-Hugo",
-            "files": [
-                "https://github.com/MoonHugo/ComfyUI-BiRefNet-Hugo"
-            ],
-            "install_type": "git-clone",
-            "description": "This repository wraps the latest BiRefNet model as ComfyUI nodes. Compared to the previous model, the latest model offers higher and better matting accuracy."
-        },
-        {
-           "author": "GrenKain",
-           "title": "PixelArt Processing Nodes",
-           "id": "gk_pixelart",
-           "reference": "https://github.com/GrenKain/PixelArt-Processing-Nodes-for-ComfyUI",
-           "files": [
-               "https://github.com/GrenKain/PixelArt-Processing-Nodes-for-ComfyUI"
-           ],
-           "install_type": "git-clone",
-           "description": "This repository provides custom nodes for ComfyUI that enable pixel art style image processing, including downscaling, upscaling, color quantization, and resolution adjustments."
-        },
-        {
-            "author": "Trgtuan10",
-            "title": "ComfyUI_YoloSegment_Mask",
-            "reference": "https://github.com/Trgtuan10/ComfyUI_YoloSegment_Mask",
-            "files": [
-                "https://github.com/Trgtuan10/ComfyUI_YoloSegment_Mask"
-            ],
-            "install_type": "git-clone",
-            "description": "NODES:Object Mask.\nNOTE:push [a/yolov8x-seg.pt](https://github.com/ultralytics/assets/releases/download/v8.2.0/yolov8x-seg.pt) in models/yolo"
-        },
-        {
-            "author": "lldacing",
-            "title": "ComfyUI_BiRefNet_ll",
-            "reference": "https://github.com/lldacing/ComfyUI_BiRefNet_ll",
-            "files": [
-                "https://github.com/lldacing/ComfyUI_BiRefNet_ll"
-            ],
-            "install_type": "git-clone",
-            "description": "NODES:AutoDownloadBiRefNetModel, LoadRembgByBiRefNetModel, RembgByBiRefNet."
-        },
-        {
-            "author": "Tenney95",
-            "title": "ComfyUI-NodeAligner",
-            "reference": "https://github.com/Tenney95/ComfyUI-NodeAligner",
-            "files": [
-                "https://github.com/Tenney95/ComfyUI-NodeAligner"
-            ],
-            "install_type": "git-clone",
-            "description": "ComfyUI-NodeAligner is a lightweight ComfyUI layout plugin that includes features such as node alignment, distribution, and resizing. This plugin is designed to simplify layout adjustments in visual node editors or custom UI components, making node arrangement more convenient and efficient."
-        },
-        {
-            "author": "VykosX",
-            "title": "ControlFlowUtils",
-            "reference": "https://github.com/VykosX/ControlFlowUtils",
-            "files": [
-                "https://github.com/VykosX/ControlFlowUtils"
-            ],
-            "install_type": "git-clone",
-            "description": "Custom nodes to improve flow control and logic + several utilities to enhance capabilities"
-        },
-
-
-
-
 
 
 
@@ -14596,6 +14457,15 @@
             ],
             "install_type": "unzip",
             "description": "This is a node to convert an image into a CMYK Halftone dot image."
-        }
-    ]
+        },
+        {
+	    "author": "PotatoBin",
+	    "title": "TripoSR Texture Generator",
+	    "id": "tripo-sr-texture-generator",
+	    "reference": "https://github.com/PotatoBin/ComfyUI-TripoSR-Texture-Gen",
+	    "install_type": "git-clone",
+	    "description": "A custom node for generating textures for 3D mesh models using advanced raycasting and Stable Diffusion in ComfyUI."
+	}
+	]
+
 }


### PR DESCRIPTION
 This pull request adds the TripoSR Texture Generator node to the custom-node-list.json file. This custom node is designed for generating textures for 3D mesh models using advanced raycasting and Stable Diffusion models in ComfyUI.

Changes:

Added the TripoSR Texture Generator node information to custom-node-list.json.
The node is hosted at https://github.com/PotatoBin/ComfyUI-TripoSR-Texture-Gen
Details:

Author: PotatoBin
Description: A custom node for generating textures for 3D mesh models using advanced raycasting and Stable Diffusion.
Version: 1.0
Please review and merge the changes. Thank you!