### PR TITLE
Fix Terminal Log node render

### DIFF
--- a/js/terminal.js
+++ b/js/terminal.js
@@ -9,11 +9,13 @@ app.registerExtension({
 	name: "Comfy.Manager.Terminal",
 
 	registerCustomNodes() {
-		class TerminalNode {
+		class TerminalNode extends LiteGraph.LGraphNode {
 			color = "#222222";
 			bgcolor = "#000000";
 			groupcolor = LGraphCanvas.node_colors.black.groupcolor;
 			constructor() {
+				super();
+				this.title = "Terminal Log (Manager)";
 				this.logs = [];
 
 				if (!this.properties) {


### PR DESCRIPTION
The Terminal node currently fails to render and throws the following error:

![Selection_324](https://github.com/user-attachments/assets/d520f3f1-2a6e-4a4c-8067-bdfe2314a0e1)

`TerminalNode` calls `ComfyWidgets.STRING`, which invokes `addDOMWidget`. `addDOMWidget` attempts to access the `addCustomWidget` property, which is defined on `LGraphNode`. Since `TerminalNode` does not subclass `LGraphNode`, it does not inherit properties like `addCustomWidget`, causing the error.

Subclassing `TerminalNode` resolves the issue:

![Selection_325](https://github.com/user-attachments/assets/3f6f5690-a2a7-4aad-a12c-72ba473d6603)

Related:

- #1039
