### PR TITLE
Please add ComfyUI Image to Painting and Inspyrenet Assistant Nodes

### DIFF
--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -14131,6 +14131,17 @@
             ],
             "install_type": "unzip",
             "description": "This is a node to convert an image into a CMYK Halftone dot image."
+        },
+        {
+            "author": "Isi-dev",
+            "title": "ComfyUI-Img2DrawingAssistants",
+            "id": "Img2DrawingAssistants",
+            "reference": "https://github.com/Isi-dev/ComfyUI-Img2DrawingAssistants",
+            "files": [
+                "https://github.com/Isi-dev/ComfyUI-Img2DrawingAssistants"
+            ],
+            "install_type": "git-clone",
+            "description": "These are ComfyUI nodes to assist in converting an image to sketches or lineArts."
         }
     ]
 }

--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -14985,6 +14985,17 @@
             ],
             "install_type": "git-clone",
             "description": "These are ComfyUI nodes to assist in converting an image to sketches or lineArts."
+        },
+        {
+            "author": "Isi-dev",
+            "title": "Image to Painting and Inspyrenet Assistant Nodes",
+            "id": "ComfyUI-Img2PaintingAssistant",
+            "reference": "https://github.com/Isi-dev/ComfyUI-Img2PaintingAssistant",
+            "files": [
+                "https://github.com/Isi-dev/ComfyUI-Img2PaintingAssistant"
+            ],
+            "install_type": "git-clone",
+            "description": "These are ComfyUI nodes to assist in converting images to paintings and to assist the Inspyrenet Rembg node to totally remove, or replace with a color, the original background from images so that the background does not reappear in videos or in nodes that do not retain the alpha channel in rgba images."
         }
     ]
 }

--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -14977,17 +14977,6 @@
         },
         {
             "author": "Isi-dev",
-            "title": "ComfyUI-Img2DrawingAssistants",
-            "id": "Img2DrawingAssistants",
-            "reference": "https://github.com/Isi-dev/ComfyUI-Img2DrawingAssistants",
-            "files": [
-                "https://github.com/Isi-dev/ComfyUI-Img2DrawingAssistants"
-            ],
-            "install_type": "git-clone",
-            "description": "These are ComfyUI nodes to assist in converting an image to sketches or lineArts."
-        },
-        {
-            "author": "Isi-dev",
             "title": "Image to Painting and Inspyrenet Assistant Nodes",
             "id": "ComfyUI-Img2PaintingAssistant",
             "reference": "https://github.com/Isi-dev/ComfyUI-Img2PaintingAssistant",


### PR DESCRIPTION
These are ComfyUI nodes to assist in converting images to paintings and to assist the ComfyUI-Inspyrenet Rembg node to totally remove, or replace with a color, the original background from images so that the background does not reappear in videos or in nodes that do not retain the alpha channel in rgba images.