### PR TITLE
model-list.json: update url for t5-v1_1-xxl_encoderonly-fp16

### DIFF
--- a/model-list.json
+++ b/model-list.json
@@ -863,7 +863,7 @@
       "description": "The encoder part of https://huggingface.co/google/t5-v1_1-xxl, used with SD3 and Flux1",
       "reference": "https://huggingface.co/mcmonkey/google_t5-v1_1-xxl_encoderonly",
       "filename": "google_t5-v1_1-xxl_encoderonly-fp16.safetensors",
-      "url": "https://huggingface.co/mcmonkey/google_t5-v1_1-xxl_encoderonly/resolve/main/pytorch_model.safetensors",
+      "url": "https://huggingface.co/mcmonkey/google_t5-v1_1-xxl_encoderonly/resolve/main/model.safetensors",
       "size": "10.1GB"
     },
     {


### PR DESCRIPTION
The filename in the git repo was changed from "pytorch_model.safetensors" to "model.safetensors":

https://huggingface.co/mcmonkey/google_t5-v1_1-xxl_encoderonly/commit/b13e9156c8ea5d48d245929610e7e4ea366c9620