### PR TITLE
model-list.json: fix save-path for flux1-dev-F16.gguf

### DIFF
--- a/model-list.json
+++ b/model-list.json
@@ -3888,7 +3888,7 @@
       "name": "city96/flux1-dev-F16.gguf",
       "type": "diffusion_model",
       "base": "FLUX.1",
-      "save_path": "diffusion_model/FLUX1",
+      "save_path": "diffusion_models/FLUX1",
       "description": "FLUX.1 [Dev] Diffusion model (f16/.gguf)",
       "reference": "https://huggingface.co/city96/FLUX.1-dev-gguf",
       "filename": "flux1-dev-F16.gguf",


### PR DESCRIPTION
The save path has a typo - it saves to the "diffusion_model" subfolder (no "s"), instead of "diffusion_models"