### PR TITLE
fix duplicate repo in custom-node-list

### DIFF
--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -12591,9 +12591,9 @@
             "author": "RhizoNymph",
             "title": "ComfyUI-CLIPSlider",
             "id": "clipslider",
-            "reference": "https://github.com/RhizoNymph/ComfyUI-Latte",
+            "reference": "https://github.com/RhizoNymph/ComfyUI-CLIPSlider",
             "files": [
-                "https://github.com/RhizoNymph/ComfyUI-Latte"
+                "https://github.com/RhizoNymph/ComfyUI-CLIPSlider"
             ],
             "install_type": "git-clone",
             "description": "A node to replicate [a/https://huggingface.co/spaces/latentexplorers/latentnavigation-flux](A node to replicate https://huggingface.co/spaces/latentexplorers/latentnavigation-flux)"


### PR DESCRIPTION
[ComfyUI-CLIPSlider](https://github.com/RhizoNymph/ComfyUI-CLIPSlider) was incorrectly referencing [ComfyUI-Latte](https://github.com/RhizoNymph/ComfyUI-Latte).