### PR TITLE
Update groupnode features to be compatible with frontend v1.2.64

### DIFF
--- a/glob/manager_core.py
+++ b/glob/manager_core.py
@@ -1135,7 +1135,7 @@ async def extract_nodes_from_workflow(filepath, mode='local', channel_url='defau
             if node_name in ['Reroute', 'Note']:
                 continue
 
-            if node_name is not None and not node_name.startswith('workflow/'):
+            if node_name is not None and not (node_name.startswith('workflow/') or node_name.startswith('workflow>')):
                 used_nodes.add(node_name)
 
     if 'nodes' in workflow:

--- a/js/components-manager.js
+++ b/js/components-manager.js
@@ -4,6 +4,8 @@ import { sleep, show_message } from "./common.js";
 import { GroupNodeConfig, GroupNodeHandler } from "../../extensions/core/groupNode.js";
 import { ComfyDialog, $el } from "../../scripts/ui.js";
 
+const SEPARATOR = ">"
+
 let pack_map = {};
 let rpack_map = {};
 
@@ -20,7 +22,7 @@ export function getPureName(node) {
 		let purename = node.comfyClass.substring(category.length+1);
 		return purename;
 	}
-	else if(node.comfyClass.startsWith('workflow/')) {
+	else if(node.comfyClass.startsWith('workflow/') || node.comfyClass.startsWith(`workflow${SEPARATOR}`)) {
 		return node.comfyClass.substring(9);
 	}
 	else {
@@ -76,7 +78,7 @@ export async function load_components() {
 
 				let category = data.packname;
 				if(data.category) {
-					category += "/" + data.category;
+					category += SEPARATOR + data.category;
 				}
 				if(category == '') {
 					category = 'components';
@@ -100,7 +102,7 @@ export async function load_components() {
 			try {
 				let category = nodeData.packname;
 				if(nodeData.category) {
-					category += "/" + nodeData.category;
+					category += SEPARATOR + nodeData.category;
 				}
 				if(category == '') {
 					category = 'components';
@@ -139,7 +141,7 @@ export async function load_components() {
 			try {
 				let category = nodeData.packname;
 				if(nodeData.workflow.category) {
-					category += "/" + nodeData.category;
+					category += SEPARATOR + nodeData.category;
 				}
 				if(category == '') {
 					category = 'components';
@@ -174,7 +176,7 @@ export async function load_components() {
 			try {
 				let category = nodeData.workflow.packname;
 				if(nodeData.workflow.category) {
-					category += "/" + nodeData.category;
+					category += SEPARATOR + nodeData.category;
 				}
 				if(category == '') {
 					category = 'components';
@@ -234,7 +236,7 @@ async function save_as_component(node, version, author, prefix, nodename, packna
 
 		let category = body.workflow.packname;
 		if(body.workflow.category) {
-			category += "/" + body.workflow.category;
+			category += SEPARATOR + body.workflow.category;
 		}
 		if(category == '') {
 			category = 'components';
@@ -266,7 +268,7 @@ async function import_component(component_name, component, mode) {
 
 	let category = component.packname;
 	if(component.category) {
-		category += "/" + component.category;
+		category += SEPARATOR + component.category;
 	}
 	if(category == '') {
 		category = 'components';
@@ -403,7 +405,7 @@ function handle_import_components(components) {
 	}
 
 	if(cnt == 1 && last_name) {
-		const node = LiteGraph.createNode(`workflow/${last_name}`);
+		const node = LiteGraph.createNode(`workflow${SEPARATOR}${last_name}`);
 		node.pos = [app.canvas.graph_mouse[0], app.canvas.graph_mouse[1]];
 		app.canvas.graph.add(node, false);
 	}
@@ -786,7 +788,7 @@ app.graphToPrompt = async function () {
 			// get used group nodes
 			let used_group_nodes = new Set();
 			for(let node of p.workflow.nodes) {
-				if(node.type.startsWith('workflow/')) {
+				if(node.type.startsWith(`workflow/`) || node.type.startsWith(`workflow${SEPARATOR}`)) {
 					used_group_nodes.add(node.type.substring(9));
 				}
 			}

--- a/js/custom-nodes-manager.js
+++ b/js/custom-nodes-manager.js
@@ -1106,7 +1106,7 @@ export class CustomNodesManager {
 
 		for (let i in nodes) {
 			const node_type = nodes[i].type;
-			if(node_type.startsWith('workflow/'))
+			if(node_type.startsWith('workflow/') || node_type.startsWith('workflow>'))
 				continue;
 
 			if (!registered_nodes.has(node_type)) {


### PR DESCRIPTION
In https://github.com/Comfy-Org/ComfyUI_frontend/pull/950, the prefix for group nodes was changed from `workflow/` to `workflow>`, which caused an issue with saving workflows when the manager was installed.

I have tested these changes on workflows containing group nodes saved from the following states:

- [Frontend-1.2.42-WITH_Manager.json](https://github.com/user-attachments/files/17138515/Frontend-1.2.42-WITH_Manager.json)
    > (before any changes to group nodes)
- [Frontend-1.2.42-WITHOUT_Manager.json](https://github.com/user-attachments/files/17138519/Frontend-1.2.42-WITHOUT_Manager.json)
    > (before any changes to group nodes)
- [Frontend-1.2.63-WITH_Manager.json](https://github.com/user-attachments/files/17138522/Frontend-1.2.63-WITH_Manager.json)
    > (After https://github.com/Comfy-Org/ComfyUI_frontend/pull/950)
- [Frontend-1.2.63-WITHOUT_Manager.json](https://github.com/user-attachments/files/17138523/Frontend-1.2.63-WITHOUT_Manager.json)
    > (After https://github.com/Comfy-Org/ComfyUI_frontend/pull/950)
- [Frontend-1.2.64-WITH_Manager.json](https://github.com/user-attachments/files/17138525/Frontend-1.2.64-WITH_Manager.json)
    > (After https://github.com/Comfy-Org/ComfyUI_frontend/pull/969)
- [Frontend-1.2.64-WITHOUT_Manager.json](https://github.com/user-attachments/files/17138531/Frontend-1.2.64-WITHOUT_Manager.json)
    > (After https://github.com/Comfy-Org/ComfyUI_frontend/pull/969)
- [Legacy-Frontend-WITH_Manager.json](https://github.com/user-attachments/files/17138535/Legacy-Frontend-WITH_Manager.json)

Any group nodes saved to workflows in the past 2 days while using the manager and the latest frontend will not be loadable since the `groupNodes` section of the workflow will have been never properly set. Example: [test.json](https://github.com/user-attachments/files/17138552/test.json)
