### PR TITLE
Add docs.comfy.org to community manual dropdown

### DIFF
--- a/js/comfyui-manager.js
+++ b/js/comfyui-manager.js
@@ -1082,6 +1082,10 @@ class ManagerMenuDialog extends ComfyDialog {
 							const menu = new LiteGraph.ContextMenu(
 								[
 									{
+										title: "ComfyUI Docs",
+										callback: () => { window.open("https://docs.comfy.org/", ""); },
+									},
+									{
 										title: "Comfy Custom Node How To",
 										callback: () => { window.open("https://github.com/chrisgoringe/Comfy-Custom-Node-How-To/wiki/aaa_index", "comfyui-community-manual1"); },
 									},


### PR DESCRIPTION
![Selection_435](https://github.com/user-attachments/assets/c3a97897-608b-46db-8348-404b15dd706a)

`ComfyUI Docs` links to <https://docs.comfy.org/>