### PR TITLE
Update install_type for ComfyUI-Molmo in custom-node-list.json

### DIFF
--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -14914,7 +14914,7 @@
              "files": [
                "https://github.com/CY-CHENYUE/ComfyUI-Molmo"
              ],
-             "install_type": "git_clone",
+             "install_type": "git-clone",
              "description": "Use of the molmo model.Generate detailed image descriptions and analysis using Molmo models in ComfyUI."
         },
 


### PR DESCRIPTION
Changed the install_type for ComfyUI-Molmo from 'git_clone' to 'git-clone' to resolve installation issues and maintain consistency with other extensions.

The nodes are already available in the manager, but the installation prompt says “ComfyUI-Molmo install failed: Bad Request”, is this related?