### PR TITLE
Add KayTool to custom-node-list.json

### DIFF
--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -16115,6 +16115,16 @@
             ],
             "install_type": "unzip",
             "description": "This is a node to convert an image into a CMYK Halftone dot image."
+        },
+        {
+            "author": "kk8bit",
+            "title": "KayTool",
+            "reference": "https://github.com/kk8bit/KayTool",
+            "files": [
+                "https://github.com/kk8bit/KayTool"
+            ],
+            "install_type": "git-clone",
+            "description": "KayTool is a growing toolkit for ComfyUI. It includes the 'Custom Save Image' node, allowing image saving in PNG or JPG format, with support for ICC profiles like sRGB and Adobe RGB, metadata control, JPG quality adjustment."
         }
     ]
 }


### PR DESCRIPTION
This PR adds KayTool to the custom-node-list.json. KayTool provides the 'Custom Save Image' node for ComfyUI, allowing image saving in PNG or JPG format, ICC profile selection, metadata control, and JPG quality adjustment.

Thank you for reviewing this PR and for maintaining such a great project!