### PR TITLE
Fix incorrect display of Terminal Log in nodes tree tab

### DIFF
--- a/js/terminal.js
+++ b/js/terminal.js
@@ -53,7 +53,7 @@ app.registerExtension({
 
 		// Load default visibility
 		LiteGraph.registerNodeType(
-			"Terminal Log //CM",
+			"Terminal Log",
 			Object.assign(TerminalNode, {
 				title_mode: LiteGraph.NORMAL_TITLE,
 				title: "Terminal Log (Manager)",


### PR DESCRIPTION
Before :

![2024-10-22_00-25](https://github.com/user-attachments/assets/c0f10f81-02c9-4d2a-95d1-98fbc53d5bc3)

After :

![2024-10-22_00-28](https://github.com/user-attachments/assets/ae88f494-a5f7-429d-b9d3-93789f6e103a)
