### PR TITLE
Add JMNodes to custom-nodes-list.json

### DIFF
--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -16489,6 +16489,17 @@
             ],
             "install_type": "unzip",
             "description": "This is a node to convert an image into a CMYK Halftone dot image."
+        },
+        {
+            "author": "JustinMatters",
+            "title": "ComfyUI JMNodes",
+            "id": "JMNodes",
+            "reference": "https://github.com/JustinMatters/comfyUI-JMNodes",
+            "files": [
+                "https://github.com/JustinMatters/comfyUI-JMNodes"
+            ],
+            "install_type": "git-clone",
+            "description": "Provides nodes to support generation of all possible combinations of a set of prompts via boolean logic"
         }
     ]
 }


### PR DESCRIPTION
Add JMNodes to ComfyUI Manager via custom-nodes-list.json. This provides nodes to support generation of all possible combinations of a set of prompts via boolean logic. These nodes are simple with no library imports required.