### PR TITLE
Added basix_image_filters to custom node list

### DIFF
--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -16808,6 +16808,17 @@
             ],
             "install_type": "unzip",
             "description": "This is a node to convert an image into a CMYK Halftone dot image."
+        },
+        {
+            "author": "basix",
+            "title": "Basix Image Filters",
+            "id": "basix_image_filters",
+            "reference": "https://github.com/maludwig/basix_image_filters",
+            "files": [
+                "https://github.com/maludwig/basix_image_filters"
+            ],
+            "install_type": "git-clone",
+            "description": "A handful of image filters for ComfyUI (darken, lighten, levels, saturate, hue)"
         }
     ]
 }


### PR DESCRIPTION
Not sure what to write here. But I made a bunch of custom nodes that I'm proud of! The actual changes here are obvious, so I guess I'll paste the top of my node's readme?



======



This is a simple image filter library for ComfyUI. It requires no fancy requirements, simply using the basic
torch and numpy libraries. It is designed to be simple and easy to use. It is super helpful for hinting to 
the AI model that you want an image to be dark, with green light. Just feed it a darked, green image, with
0.7 - 0.9 denoise, and you'll get a darker, greener output.

All nodes take an image as input, and output an image.
The nodes also all take a mask as an optional input, if a mask is provided:
- And the masked_area is set to modify_unmasked, the image will be modified outside the mask
- And the masked_area is set to modify_masked, the image will be modified inside the mask

This way, you can easily take an image that is "ok except for the ___" and modify only the area you want to change.
This is built into ComfyUI (not part of this plugin), simply right-click on a Preview Image node, and Copy (Clipspace),
then make a Load Image node, and right-click that, and then Paste (Clipspace). You will now be able to right-click it,
and "Open in MaskEditor" to create a mask.
On Windows, Shift+Click-and-drag to zoom in and out, and Ctrl+click-and-drag to move the mask.
On OSX, try it out and let me know. I'm not rich enough to buy Apple hardware. haha.
