### PR TITLE
fix: use `${comfy_path}/custom_nodes` as `custom_nodes_path`

### DIFF
--- a/glob/manager_core.py
+++ b/glob/manager_core.py
@@ -28,11 +28,12 @@ version_str = f"V{version[0]}.{version[1]}" + (f'.{version[2]}' if len(version) 
 
 
 comfyui_manager_path = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
-custom_nodes_path = os.path.abspath(os.path.join(comfyui_manager_path, '..'))
 
 comfy_path = os.environ.get('COMFYUI_PATH')
 if comfy_path is None:
-    comfy_path = os.path.abspath(os.path.join(custom_nodes_path, '..'))
+    comfy_path = os.path.abspath(os.path.join(comfyui_manager_path, '..', '..'))
+
+custom_nodes_path = os.path.abspath(os.path.join(comfy_path, 'custom_nodes'))
 
 channel_list_path = os.path.join(comfyui_manager_path, 'channels.list')
 config_path = os.path.join(comfyui_manager_path, "config.ini")


### PR DESCRIPTION
When I use `cm-cli.py` as a utility to manager my ComfyUI service extension (not in `custom_nodes` of ComfyUI), I can export the `COMFYUI_PATH` environment variable as the ComfyUI directory, which is also mentioned in [cm-cli.py doc](https://github.com/ltdrdata/ComfyUI-Manager/blob/main/docs/en/cm-cli.md#prerequisite).

However, some functions didn't work as expected, like `python cm-cli.py save-snapshot`. That's because `cm-cli.py` will invoke methods in `manager_core.py`, and resolve `custom_nodes_paths` as `${comfyui_manager_path}/../..`, not `${comfy_path}/custom_nodes`. This will result some unexpected output, and `COMFYUI_PATH` will become meaningless in these related methods.

In my point, if ComfyUI-Manager allows user indicate ComfyUI directory by `COMFYUI_PATH`, other related path should base on `COMFYUI_PATH`, rather than `${comfyui_manager_path}`, because `COMFYUI_PATH` is more reliable, and it makes `cm-cli.py` and `manager_core.py` behave more consistent.

Thank you for your time and consideration.
Best regards.