### PR TITLE
manager_core: Fix fetch/update line erasure output issues

### DIFF
--- a/glob/manager_core.py
+++ b/glob/manager_core.py
@@ -367,13 +367,13 @@ def __win_check_git_update(path, do_fetch=False, do_update=False):
     if do_update:
         if "CUSTOM NODE PULL: Success" in output:
             process.wait()
-            print(f"\rUpdated: {path}")
+            print(f"\x1b[2K\rUpdated: {path}")
             return True, True    # updated
         elif "CUSTOM NODE PULL: None" in output:
             process.wait()
             return False, True   # there is no update
         else:
-            print(f"\rUpdate error: {path}")
+            print(f"\x1b[2K\rUpdate error: {path}")
             process.wait()
             return False, False  # update failed
     else:
@@ -384,7 +384,7 @@ def __win_check_git_update(path, do_fetch=False, do_update=False):
             process.wait()
             return False, True
         else:
-            print(f"\rFetch error: {path}")
+            print(f"\x1b[2K\rFetch error: {path}")
             print(f"\n{output}\n")
             process.wait()
             return False, True


### PR DESCRIPTION
* __win_check_git_update: Properly cleanup line before using a carriage return to return to the beginning. This prevents output like:
```
  Updated: S:\ComfyUI\custom_nodes\ComfyUI-Impact-Packrpolation
  Updated: S:\ComfyUI\custom_nodes\comfyui-inpaint-nodesayout
  Updated: S:\ComfyUI\custom_nodes\ComfyUI-LogicUtilsodes
```
  In this case the node being updated overlaps the existing output showing nodes being checked for updates. This happens because there's no erase until end of line being used in the windows specific function whereas the non-windows version uses it in git_repo_has_updates.