### PR TITLE
Bypass ComfyUI version check when in electron env

### DIFF
--- a/glob/manager_core.py
+++ b/glob/manager_core.py
@@ -82,6 +82,7 @@ comfy_ui_required_commit_datetime = datetime(2024, 1, 24, 0, 0, 0)
 comfy_ui_revision = "Unknown"
 comfy_ui_commit_datetime = datetime(1900, 1, 1, 0, 0, 0)
 
+is_electron = os.environ.get("ORIGINAL_XDG_CURRENT_DESKTOP") != None
 
 cache_lock = threading.Lock()
 

--- a/glob/manager_core.py
+++ b/glob/manager_core.py
@@ -53,8 +53,8 @@ def get_custom_nodes_paths():
 
 
 def get_comfyui_tag():
-    repo = git.Repo(comfy_path)
     try:
+        repo = git.Repo(comfy_path)
         return repo.git.describe('--tags')
     except:
         return None

--- a/glob/manager_server.py
+++ b/glob/manager_server.py
@@ -12,6 +12,7 @@ import re
 import shutil
 import git
 import datetime
+import logging
 
 from server import PromptServer
 import manager_core as core
@@ -1226,8 +1227,8 @@ async def get_notice(request):
                             markdown_content = f'<P style="text-align: center; color:red; background-color:white; font-weight:bold">Your ComfyUI isn\'t git repo.</P>' + markdown_content
                         elif core.comfy_ui_required_commit_datetime.date() > core.comfy_ui_commit_datetime.date():
                             markdown_content = f'<P style="text-align: center; color:red; background-color:white; font-weight:bold">Your ComfyUI is too OUTDATED!!!</P>' + markdown_content
-                    except:
-                        pass
+                    except Exception as error:
+                        logging.warning("Unexpected error when checking ComfyUI version via git.")
 
                     return web.Response(text=markdown_content, status=200)
                 else:

--- a/glob/manager_server.py
+++ b/glob/manager_server.py
@@ -1219,7 +1219,9 @@ async def get_notice(request):
                     markdown_content = add_target_blank(markdown_content)
 
                     try:
-                        if core.comfy_ui_commit_datetime == datetime(1900, 1, 1, 0, 0, 0):
+                        if core.is_electron:
+                            pass
+                        elif core.comfy_ui_commit_datetime == datetime(1900, 1, 1, 0, 0, 0):
                             markdown_content = f'<P style="text-align: center; color:red; background-color:white; font-weight:bold">Your ComfyUI isn\'t git repo.</P>' + markdown_content
                         elif core.comfy_ui_required_commit_datetime.date() > core.comfy_ui_commit_datetime.date():
                             markdown_content = f'<P style="text-align: center; color:red; background-color:white; font-weight:bold">Your ComfyUI is too OUTDATED!!!</P>' + markdown_content

--- a/glob/manager_server.py
+++ b/glob/manager_server.py
@@ -11,6 +11,7 @@ import threading
 import re
 import shutil
 import git
+import datetime
 
 from server import PromptServer
 import manager_core as core
@@ -1221,7 +1222,7 @@ async def get_notice(request):
                     try:
                         if core.is_electron:
                             pass
-                        elif core.comfy_ui_commit_datetime == datetime(1900, 1, 1, 0, 0, 0):
+                        elif core.comfy_ui_commit_datetime == datetime.datetime(1900, 1, 1, 0, 0, 0):
                             markdown_content = f'<P style="text-align: center; color:red; background-color:white; font-weight:bold">Your ComfyUI isn\'t git repo.</P>' + markdown_content
                         elif core.comfy_ui_required_commit_datetime.date() > core.comfy_ui_commit_datetime.date():
                             markdown_content = f'<P style="text-align: center; color:red; background-color:white; font-weight:bold">Your ComfyUI is too OUTDATED!!!</P>' + markdown_content


### PR DESCRIPTION
#### User changes
- Fixes bug - version too outdated & not in repo warnings are never displayed
- When using desktop, ComfyUI version check is skipped (handled by app)

#### Code / dev changes
- Duplicate of https://github.com/ltdrdata/ComfyUI-Manager/pull/1303
- Detects Electron by via environment var (set by Electron itself)
- If debugging in an IDE built with Electron, this value will very likely be set