### PR TITLE
Add support for custom node only snapshots

### DIFF
--- a/cm-cli.py
+++ b/cm-cli.py
@@ -842,14 +842,20 @@ def save_snapshot(
                 show_default=False, help="Specify the output file path. (.json/.yaml)"
             ),
         ] = None,
+        full_snapshot: Annotated[
+            bool,
+            typer.Option(
+                show_default=False, help="If the snapshot should include custom node, ComfyUI version and pip versions (default), or only custom node details"
+            ),
+        ] = True,
 ):
-    path = core.save_snapshot_with_postfix('snapshot', output)
+    path = core.save_snapshot_with_postfix('snapshot', output, not full_snapshot)
     print(f"Current snapshot is saved as `{path}`")
 
 
 @app.command("restore-snapshot", help="Restore snapshot from snapshot file")
 def restore_snapshot(
-        snapshot_name: str,
+        snapshot_name: str, 
         pip_non_url: Optional[bool] = typer.Option(
             default=None,
             show_default=False,

--- a/git_helper.py
+++ b/git_helper.py
@@ -332,12 +332,13 @@ def apply_snapshot(target):
                 git_custom_node_infos = info['git_custom_nodes']
                 file_custom_node_infos = info['file_custom_nodes']
 
-                checkout_comfyui_hash(comfyui_hash)
+                if comfyui_hash:
+                    checkout_comfyui_hash(comfyui_hash)
                 checkout_custom_node_hash(git_custom_node_infos)
                 invalidate_custom_node_file(file_custom_node_infos)
 
                 print("APPLY SNAPSHOT: True")
-                if 'pips' in info:
+                if 'pips' in info and info['pips']:
                     return info['pips']
                 else:
                     return None

--- a/glob/manager_core.py
+++ b/glob/manager_core.py
@@ -1080,7 +1080,7 @@ def get_installed_pip_packages():
     return res
 
 
-def get_current_snapshot():
+def get_current_snapshot(custom_nodes_only = False):
     # Get ComfyUI hash
     repo_path = comfy_path
 
@@ -1088,8 +1088,10 @@ def get_current_snapshot():
         print(f"ComfyUI update fail: The installed ComfyUI does not have a Git repository.")
         return {}
 
-    repo = git.Repo(repo_path)
-    comfyui_commit_hash = repo.head.commit.hexsha
+    comfyui_commit_hash = None
+    if not custom_nodes_only:
+        repo = git.Repo(repo_path)
+        comfyui_commit_hash = repo.head.commit.hexsha
 
     git_custom_nodes = {}
     file_custom_nodes = []
@@ -1135,7 +1137,7 @@ def get_current_snapshot():
 
                 file_custom_nodes.append(item)
 
-    pip_packages = get_installed_pip_packages()
+    pip_packages = None if custom_nodes_only else get_installed_pip_packages()
 
     return {
         'comfyui': comfyui_commit_hash,
@@ -1145,7 +1147,7 @@ def get_current_snapshot():
     }
 
 
-def save_snapshot_with_postfix(postfix, path=None):
+def save_snapshot_with_postfix(postfix, path=None, custom_nodes_only = False):
     if path is None:
         now = datetime.now()
 
@@ -1157,7 +1159,7 @@ def save_snapshot_with_postfix(postfix, path=None):
         file_name = path.replace('\\', '/').split('/')[-1]
         file_name = file_name.split('.')[-2]
 
-    snapshot = get_current_snapshot()
+    snapshot = get_current_snapshot(custom_nodes_only)
     if path.endswith('.json'):
         with open(path, "w") as json_file:
             json.dump(snapshot, json_file, indent=4)


### PR DESCRIPTION
Adds --full-snapshot / --no-full-snapshot, defaulting to full as current behavior
If not full, only includes custom_node details.

Used by the desktop app for custom node migration