### PR TITLE
Remove call to non-exist endpoint /component/get_unresolved

### DIFF
--- a/js/custom-nodes-manager.js
+++ b/js/custom-nodes-manager.js
@@ -1125,17 +1125,6 @@ export class CustomNodesManager {
 			}
 		}
 
-		const resUnresolved = await fetchData(`/component/get_unresolved`);
-		const unresolved = resUnresolved.data;
-		if (unresolved && unresolved.nodes) {
-			unresolved.nodes.forEach(node_type => {
-				const url = name_to_urls[node_type];
-				if(url) {
-					missing_nodes.add(url);
-				}
-			});
-		}
-
 		const hashMap = {};
 		this.custom_nodes.forEach(item => {
 			if (item.files.some(file => missing_nodes.has(file))) {


### PR DESCRIPTION
This PR removes a call to `/component/get_unresolved` that does not exist.

## Verification Steps:
- Load any workflow
- Open Manager dialog
- Click install missing nodes
- Observe 404 in console

![Screenshot 2024-12-16 at 4 38 11 PM](https://github.com/user-attachments/assets/e983c43c-98f0-42a9-8782-946b39154a76)

## Refs
The call was moved in #744. I think the backend api route was removed but the call is not cleaned up.
