### PR TITLE
Enable pyflake ruff lint rules

### DIFF
--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -1,0 +1,23 @@
+name: Python Linting
+
+on: [push, pull_request]
+
+jobs:
+  ruff:
+    name: Run Ruff
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.x
+
+    - name: Install Ruff
+      run: pip install ruff
+
+    - name: Run Ruff
+      run: ruff check .

--- a/__init__.py
+++ b/__init__.py
@@ -5,11 +5,11 @@ cli_mode_flag = os.path.join(os.path.dirname(__file__), '.enable-cli-only-mode')
 
 if not os.path.exists(cli_mode_flag):
     sys.path.append(os.path.join(os.path.dirname(__file__), "glob"))
-    import manager_server
-    import share_3rdparty
+    import manager_server  # noqa: F401
+    import share_3rdparty  # noqa: F401
     WEB_DIRECTORY = "js"
 else:
-    print(f"\n[ComfyUI-Manager] !! cli-only-mode is enabled !!\n")
+    print("\n[ComfyUI-Manager] !! cli-only-mode is enabled !!\n")
 
 NODE_CLASS_MAPPINGS = {}
 __all__ = ['NODE_CLASS_MAPPINGS']

--- a/cm-cli.py
+++ b/cm-cli.py
@@ -24,7 +24,7 @@ comfyui_manager_path = os.path.dirname(__file__)
 comfy_path = os.environ.get('COMFYUI_PATH')
 
 if comfy_path is None:
-    print(f"\n[bold yellow]WARN: The `COMFYUI_PATH` environment variable is not set. Assuming `custom_nodes/ComfyUI-Manager/../../` as the ComfyUI path.[/bold yellow]", file=sys.stderr)
+    print("\n[bold yellow]WARN: The `COMFYUI_PATH` environment variable is not set. Assuming `custom_nodes/ComfyUI-Manager/../../` as the ComfyUI path.[/bold yellow]", file=sys.stderr)
     comfy_path = os.path.abspath(os.path.join(comfyui_manager_path, '..', '..'))
 
 startup_script_path = os.path.join(comfyui_manager_path, "startup-scripts")
@@ -48,7 +48,6 @@ def check_comfyui_hash():
     repo = git.Repo(comfy_path)
     core.comfy_ui_revision = len(list(repo.iter_commits('HEAD')))
 
-    comfy_ui_hash = repo.head.commit.hexsha
     cm_global.variables['comfyui.revision'] = core.comfy_ui_revision
 
     core.comfy_ui_commit_datetime = repo.head.commit.committed_datetime
@@ -141,7 +140,7 @@ class Ctx:
         total = len(node_paths)
         i = 1
         for x in node_paths:
-            print(f"----------------------------------------------------------------------------------------------------")
+            print("----------------------------------------------------------------------------------------------------")
             print(f"Restoring [{i}/{total}]: {x}")
             self.post_install(x)
             i += 1
@@ -754,13 +753,13 @@ def cli_only_mode(
         )):
     cli_mode_flag = os.path.join(os.path.dirname(__file__), '.enable-cli-only-mode')
     if mode.lower() == 'enable':
-        with open(cli_mode_flag, 'w') as file:
+        with open(cli_mode_flag, 'w'):
             pass
-        print(f"\nINFO: `cli-only-mode` is enabled\n")
+        print("\nINFO: `cli-only-mode` is enabled\n")
     elif mode.lower() == 'disable':
         if os.path.exists(cli_mode_flag):
             os.remove(cli_mode_flag)
-        print(f"\nINFO: `cli-only-mode` is disabled\n")
+        print("\nINFO: `cli-only-mode` is disabled\n")
     else:
         print(f"\n[bold red]Invalid value for cli-only-mode: {mode}[/bold red]\n")
         exit(1)
@@ -896,7 +895,7 @@ def restore_snapshot(
                 elif 'APPLY SNAPSHOT: False' in x:
                     is_failed = True
 
-        print(f"Restore snapshot.")
+        print("Restore snapshot.")
         cmd_str = [sys.executable, git_script_path, '--apply-snapshot', snapshot_path] + extras
         output = subprocess.check_output(cmd_str, cwd=custom_nodes_path, text=True)
         msg_lines = output.split('\n')
@@ -935,7 +934,7 @@ def restore_dependencies():
     total = len(node_paths)
     i = 1
     for x in node_paths:
-        print(f"----------------------------------------------------------------------------------------------------")
+        print("----------------------------------------------------------------------------------------------------")
         print(f"Restoring [{i}/{total}]: {x}")
         cm_ctx.post_install(x)
         i += 1
@@ -1028,4 +1027,4 @@ if __name__ == '__main__':
     sys.argv[0] = re.sub(r'(-script\.pyw|\.exe)?$', '', sys.argv[0])
     sys.exit(app())
 
-print(f"")
+print("")

--- a/git_helper.py
+++ b/git_helper.py
@@ -41,7 +41,7 @@ nodelist_path = os.path.join(os.path.dirname(__file__), "custom-node-list.json")
 working_directory = os.getcwd()
 
 if os.path.basename(working_directory) != 'custom_nodes':
-    print(f"WARN: This script should be executed in custom_nodes dir")
+    print("WARN: This script should be executed in custom_nodes dir")
     print(f"DBG: INFO {working_directory}")
     print(f"DBG: INFO {sys.argv}")
     # exit(-1)

--- a/glob/manager_core.py
+++ b/glob/manager_core.py
@@ -21,7 +21,7 @@ glob_path = os.path.join(os.path.dirname(__file__))  # ComfyUI-Manager/glob
 sys.path.append(glob_path)
 
 import cm_global
-from manager_util import *
+from manager_util import PIPFixer, StrictVersion
 
 version = [2, 55, 5]
 version_str = f"V{version[0]}.{version[1]}" + (f'.{version[2]}' if len(version) > 2 else '')
@@ -116,8 +116,8 @@ def get_installed_packages():
                         continue
 
                     pip_map[y[0]] = y[1]
-        except subprocess.CalledProcessError as e:
-            print(f"[ComfyUI-Manager] Failed to retrieve the information of installed pip packages.")
+        except subprocess.CalledProcessError:
+            print("[ComfyUI-Manager] Failed to retrieve the information of installed pip packages.")
             return set()
 
     return pip_map
@@ -351,7 +351,7 @@ def try_install_script(url, repo_path, install_cmd, instant_execution=False):
                 if comfy_ui_commit_datetime.date() < comfy_ui_required_commit_datetime.date():
                     print("\n\n###################################################################")
                     print(f"[WARN] ComfyUI-Manager: Your ComfyUI version ({comfy_ui_revision})[{comfy_ui_commit_datetime.date()}] is too old. Please update to the latest version.")
-                    print(f"[WARN] The extension installation feature may not work properly in the current installed ComfyUI version on Windows environment.")
+                    print("[WARN] The extension installation feature may not work properly in the current installed ComfyUI version on Windows environment.")
                     print("###################################################################\n\n")
             except:
                 pass
@@ -390,7 +390,7 @@ def __win_check_git_update(path, do_fetch=False, do_update=False):
             output, _ = process.communicate()
             output = output.decode('utf-8').strip()
         except Exception:
-            print(f'[ComfyUI-Manager] failed to fixing')
+            print('[ComfyUI-Manager] failed to fixing')
 
         if 'detected dubious' in output:
             print(f'\n[ComfyUI-Manager] Failed to fixing repository setup. Please execute this command on cmd: \n'
@@ -468,7 +468,7 @@ def execute_install_script(url, repo_path, lazy_mode=False, instant_execution=Fa
             pip_fixer.fix_broken()
 
         if os.path.exists(install_script_path):
-            print(f"Install: install script")
+            print("Install: install script")
             install_cmd = [sys.executable, "install.py"]
             try_install_script(url, repo_path, install_cmd, instant_execution=instant_execution)
 
@@ -663,7 +663,7 @@ async def get_data(uri, silent=False):
 
     json_obj = json.loads(json_text)
     if not silent:
-        print(f" [DONE]")
+        print(" [DONE]")
     return json_obj
 
 
@@ -942,7 +942,7 @@ def update_path(repo_path, instant_execution=False):
         remote.fetch()
     except Exception as e:
         if 'detected dubious' in str(e):
-            print(f"[ComfyUI-Manager] Try fixing 'dubious repository' error on 'ComfyUI' repository")
+            print("[ComfyUI-Manager] Try fixing 'dubious repository' error on 'ComfyUI' repository")
             safedir_path = comfy_path.replace('\\', '/')
             subprocess.run(['git', 'config', '--global', '--add', 'safe.directory', safedir_path])
             try:
@@ -1084,7 +1084,7 @@ def get_current_snapshot():
     repo_path = comfy_path
 
     if not os.path.exists(os.path.join(repo_path, '.git')):
-        print(f"ComfyUI update fail: The installed ComfyUI does not have a Git repository.")
+        print("ComfyUI update fail: The installed ComfyUI does not have a Git repository.")
         return {}
 
     repo = git.Repo(repo_path)

--- a/glob/manager_util.py
+++ b/glob/manager_util.py
@@ -84,8 +84,8 @@ def get_installed_packages(renew=False):
                         continue
 
                     pip_map[y[0]] = y[1]
-        except subprocess.CalledProcessError as e:
-            print(f"[ComfyUI-Manager] Failed to retrieve the information of installed pip packages.")
+        except subprocess.CalledProcessError:
+            print("[ComfyUI-Manager] Failed to retrieve the information of installed pip packages.")
             return set()
 
     return pip_map
@@ -154,9 +154,9 @@ class PIPFixer:
                 cmd = [sys.executable, '-m', 'pip', 'uninstall', 'comfy']
                 subprocess.check_output(cmd, universal_newlines=True)
 
-                print(f"[manager-core] 'comfy' python package is uninstalled.\nWARN: The 'comfy' package is completely unrelated to ComfyUI and should never be installed as it causes conflicts with ComfyUI.")
+                print("[manager-core] 'comfy' python package is uninstalled.\nWARN: The 'comfy' package is completely unrelated to ComfyUI and should never be installed as it causes conflicts with ComfyUI.")
         except Exception as e:
-            print(f"[manager-core] Failed to uninstall `comfy` python package")
+            print("[manager-core] Failed to uninstall `comfy` python package")
             print(e)
 
         # fix torch - reinstall torch packages if version is changed
@@ -166,7 +166,7 @@ class PIPFixer:
                 or self.prev_pip_versions['torchaudio'] != new_pip_versions['torchaudio']:
                     self.torch_rollback()
         except Exception as e:
-            print(f"[manager-core] Failed to restore PyTorch")
+            print("[manager-core] Failed to restore PyTorch")
             print(e)
 
         # fix opencv
@@ -200,7 +200,7 @@ class PIPFixer:
 
                     print(f"[manager-core] 'opencv' dependencies were fixed: {targets}")
         except Exception as e:
-            print(f"[manager-core] Failed to restore opencv")
+            print("[manager-core] Failed to restore opencv")
             print(e)
 
         # fix numpy
@@ -208,7 +208,7 @@ class PIPFixer:
             np = new_pip_versions.get('numpy')
             if np is not None:
                 if StrictVersion(np) >= StrictVersion('2'):
-                    subprocess.check_output([sys.executable, '-m', 'pip', 'install', f"numpy<2"], universal_newlines=True)
+                    subprocess.check_output([sys.executable, '-m', 'pip', 'install', "numpy<2"], universal_newlines=True)
         except Exception as e:
-            print(f"[manager-core] Failed to restore numpy")
+            print("[manager-core] Failed to restore numpy")
             print(e)

--- a/glob/security_check.py
+++ b/glob/security_check.py
@@ -109,7 +109,7 @@ https://blog.comfy.org/comfyui-statement-on-the-ultralytics-crypto-miner-situati
 
         for x in detected:
             print(f"\n======== TARGET: {x} =========")
-            print(f"\nTODO:")
+            print("\nTODO:")
             print(guide.get(x))
 
         exit(-1)

--- a/glob/share_3rdparty.py
+++ b/glob/share_3rdparty.py
@@ -178,8 +178,6 @@ async def api_get_comfyworkflows_auth(request):
 @PromptServer.instance.routes.post("/manager/set_esheep_workflow_and_images")
 async def set_esheep_workflow_and_images(request):
     json_data = await request.json()
-    current_workflow = json_data['workflow']
-    images = json_data['images']
     with open(os.path.join(core.comfyui_manager_path, "esheep_share_message.json"), "w", encoding='utf-8') as file:
         json.dump(json_data, file, indent=4)
         return web.Response(status=200)
@@ -368,9 +366,9 @@ async def share_art(request):
                 text_content += f"{description}\n"
             if credits:
                 text_content += f"\ncredits: {credits}\n"
-            response = matrix.send_message(comfyui_share_room_id, text_content)
-            response = matrix.send_content(comfyui_share_room_id, mxc_url, filename, 'm.image')
-            response = matrix.send_content(comfyui_share_room_id, workflow_json_mxc_url, 'workflow.json', 'm.file')
+            matrix.send_message(comfyui_share_room_id, text_content)
+            matrix.send_content(comfyui_share_room_id, mxc_url, filename, 'm.image')
+            matrix.send_content(comfyui_share_room_id, workflow_json_mxc_url, 'workflow.json', 'm.file')
         except:
             import traceback
             traceback.print_exc()

--- a/prestartup_script.py
+++ b/prestartup_script.py
@@ -15,7 +15,7 @@ glob_path = os.path.join(os.path.dirname(__file__), "glob")
 sys.path.append(glob_path)
 
 import security_check
-from manager_util import *
+from manager_util import PIPFixer, StrictVersion, get_installed_packages, clear_pip_cache
 import cm_global
 
 security_check.security_check()
@@ -309,27 +309,26 @@ except Exception as e:
 
 
 try:
-    import git
+    import git  # noqa: F401
 except ModuleNotFoundError:
     my_path = os.path.dirname(__file__)
     requirements_path = os.path.join(my_path, "requirements.txt")
 
-    print(f"## ComfyUI-Manager: installing dependencies. (GitPython)")
+    print("## ComfyUI-Manager: installing dependencies. (GitPython)")
     try:
         result = subprocess.check_output([sys.executable, '-s', '-m', 'pip', 'install', '-r', requirements_path])
-    except subprocess.CalledProcessError as e:
-        print(f"## [ERROR] ComfyUI-Manager: Attempting to reinstall dependencies using an alternative method.")
+    except subprocess.CalledProcessError:
+        print("## [ERROR] ComfyUI-Manager: Attempting to reinstall dependencies using an alternative method.")
         try:
             result = subprocess.check_output([sys.executable, '-s', '-m', 'pip', 'install', '--user', '-r', requirements_path])
-        except subprocess.CalledProcessError as e:
-            print(f"## [ERROR] ComfyUI-Manager: Failed to install the GitPython package in the correct Python environment. Please install it manually in the appropriate environment. (You can seek help at https://app.element.io/#/room/%23comfyui_space%3Amatrix.org)")
+        except subprocess.CalledProcessError:
+            print("## [ERROR] ComfyUI-Manager: Failed to install the GitPython package in the correct Python environment. Please install it manually in the appropriate environment. (You can seek help at https://app.element.io/#/room/%23comfyui_space%3Amatrix.org)")
 
 try:
-    import git
-    print(f"## ComfyUI-Manager: installing dependencies done.")
+    print("## ComfyUI-Manager: installing dependencies done.")
 except:
     # maybe we should sys.exit() here? there is at least two screens worth of error messages still being pumped after our error messages
-    print(f"## [ERROR] ComfyUI-Manager: GitPython package seems to be installed, but failed to load somehow. Make sure you have a working git client installed")
+    print("## [ERROR] ComfyUI-Manager: GitPython package seems to be installed, but failed to load somehow. Make sure you have a working git client installed")
 
 
 print("** ComfyUI startup time:", datetime.datetime.now())
@@ -374,7 +373,7 @@ def check_bypass_ssl():
         default_conf = config['default']
 
         if 'bypass_ssl' in default_conf and default_conf['bypass_ssl'].lower() == 'true':
-            print(f"[ComfyUI-Manager] WARN: Unsafe - SSL verification bypass option is Enabled. (see ComfyUI-Manager/config.ini)")
+            print("[ComfyUI-Manager] WARN: Unsafe - SSL verification bypass option is Enabled. (see ComfyUI-Manager/config.ini)")
             ssl._create_default_https_context = ssl._create_unverified_context  # SSL certificate error fix.
     except Exception:
         pass
@@ -457,7 +456,7 @@ if os.path.exists(restore_snapshot_path):
                     else:
                         print(prefix, msg, end="")
 
-        print(f"[ComfyUI-Manager] Restore snapshot.")
+        print("[ComfyUI-Manager] Restore snapshot.")
         cmd_str = [sys.executable, git_script_path, '--apply-snapshot', restore_snapshot_path]
 
         new_env = os.environ.copy()
@@ -507,13 +506,13 @@ if os.path.exists(restore_snapshot_path):
                 print(f"[ComfyUI-Manager] Restoring '{repository_name}' is failed.")
 
         if exit_code != 0:
-            print(f"[ComfyUI-Manager] Restore snapshot failed.")
+            print("[ComfyUI-Manager] Restore snapshot failed.")
         else:
-            print(f"[ComfyUI-Manager] Restore snapshot done.")
+            print("[ComfyUI-Manager] Restore snapshot done.")
 
     except Exception as e:
         print(e)
-        print(f"[ComfyUI-Manager] Restore snapshot failed.")
+        print("[ComfyUI-Manager] Restore snapshot failed.")
 
     os.remove(restore_snapshot_path)
 
@@ -618,7 +617,7 @@ def check_windows_event_loop_policy():
                 import asyncio
                 import asyncio.windows_events
                 asyncio.set_event_loop_policy(asyncio.windows_events.WindowsSelectorEventLoopPolicy())
-                print(f"[ComfyUI-Manager] Windows event loop policy mode enabled")
+                print("[ComfyUI-Manager] Windows event loop policy mode enabled")
             except Exception as e:
                 print(f"[ComfyUI-Manager] WARN: Windows initialization fail: {e}")
     except Exception:

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,12 @@
+# Disable all rules by default
+lint.ignore = ["ALL"]
+
+# Enable specific rules
+lint.select = [
+    "S307",  # suspicious-eval-usage
+    # The "F" series in Ruff stands for "Pyflakes" rules, which catch various Python syntax errors and undefined names.
+    # See all rules here: https://docs.astral.sh/ruff/rules/#pyflakes-f
+    "F",
+]
+
+exclude = ["*.ipynb"]

--- a/scanner.py
+++ b/scanner.py
@@ -69,7 +69,7 @@ def extract_nodes(code_text):
 
     try:
         if parse_cnt % 100 == 0:
-            print(f".", end="", flush=True)
+            print(".", end="", flush=True)
         parse_cnt += 1
 
         code_text = re.sub(r'\\[^"\']', '', code_text)
@@ -515,7 +515,7 @@ def gen_json(node_info):
             nodes.sort()
             data[git_url] = (nodes, metadata_in_url)
 
-    json_path = f"extension-node-map.json"
+    json_path = "extension-node-map.json"
     with open(json_path, "w", encoding='utf-8') as file:
         json.dump(data, file, indent=4, sort_keys=True)
 


### PR DESCRIPTION
This PR enables the same ruff lint rules as in the main ComfyUI repo in preparation of eventual merge of manager to the core repo.

Ref: https://github.com/comfyanonymous/ComfyUI/pull/6033

Fixes are:
- unnecessary use of f-string
- used undefined variable (missing datetime import)
- unused variable
- "*" import
- redefinition of same function name
