### PR TITLE
Add ComfyUI-MultiGPU to custom-node-list.json

### DIFF
--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -18536,10 +18536,17 @@
             "install_type": "copy",
             "description": "Extremely inspired and forked from: [a/https://github.com/klimaleksus/stable-diffusion-webui-embedding-merge](https://github.com/klimaleksus/stable-diffusion-webui-embedding-merge)"
         },
-
-
-
-
+        {
+            "author": "pollockjj",
+            "title": "ComfyUI-MultiGPU",
+            "id": "manager",
+            "reference": "https://github.com/pollockjj/ComfyUI-MultiGPU",
+            "files": [
+                "https://github.com/pollockjj/ComfyUI-MultiGPU"
+            ],
+            "install_type": "git-clone",
+            "description": "Experimental nodes for using multiple GPUs in a single ComfyUI workflow."
+        },
         {
             "author": "theally",
             "title": "TheAlly's Custom Nodes",

--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -18544,7 +18544,7 @@
                 "https://github.com/pollockjj/ComfyUI-MultiGPU"
             ],
             "install_type": "git-clone",
-            "description": "Experimental nodes for using multiple GPUs in a single ComfyUI workflow."
+            "description": "Experimental nodes for using multiple GPUs in a single ComfyUI workflow.\nOriginal repo: [a/https://github.com/neuratech-ai/ComfyUI-MultiGPU](https://github.com/neuratech-ai/ComfyUI-MultiGPU)"
         },
         {
             "author": "theally",

--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -18539,7 +18539,6 @@
         {
             "author": "pollockjj",
             "title": "ComfyUI-MultiGPU",
-            "id": "manager",
             "reference": "https://github.com/pollockjj/ComfyUI-MultiGPU",
             "files": [
                 "https://github.com/pollockjj/ComfyUI-MultiGPU"


### PR DESCRIPTION
https://github.com/neuratech-ai/ComfyUI-MultiGPU is a custom node I use every day, but it isn't in the ComfyUI Manager list and has not been maintained. The ltxv and mochi Clip formats are not available for the Single Clip loader, for example. My intent is to keep this node current with existing loader options. It is a simple custom node in that respect.