### PR TITLE
Use module name without @Version in /customnode/installed object key

### DIFF
--- a/glob/manager_server.py
+++ b/glob/manager_server.py
@@ -546,25 +546,33 @@ def populate_markdown(x):
 async def installed_list(request):
     result = {}
     for x in folder_paths.get_folder_paths('custom_nodes'):
-        for y in os.listdir(x):
-            if y.endswith('.disabled') or y == '__pycache__' or y.endswith('.py') or y.endswith('.example'):
+        for module_name in os.listdir(x):
+            if (
+                module_name.endswith('.disabled') or
+                module_name == '__pycache__' or
+                module_name.endswith('.py') or
+                module_name.endswith('.example') or
+                module_name.endswith('.pyc')
+            ):
                 continue
 
-            spec = y.split('@')
+            spec = module_name.split('@')
 
             if len(spec) == 2:
+                node_package_name = spec[0]
                 ver = spec[1].replace('_', '.')
 
                 if ver == 'nightly':
                     ver = None
             else:
+                node_package_name = module_name
                 ver = None
 
             # extract commit hash
             if ver is None:
-                ver = core.get_commit_hash(os.path.join(x, y))
+                ver = core.get_commit_hash(os.path.join(x, node_package_name))
 
-            result[y] = ver
+            result[node_package_name] = ver
 
     return web.json_response(result, content_type='application/json')
 


### PR DESCRIPTION
Before:
```json
{
  "ComfyUI-disty-Flow": "aba029a46c60b0493ddd46a8a9ad3c2e0b501cd5",
  "ComfyUI-Manager": "9b5adfeb2c244cf6168a42fb2925b3b3f38d2a36",
  "comfyui-easy-use@1_2_5": "1.2.5", <-----
  "ComfyUI_devtools": "b9ce1265b3786da85812adcc97c8421ef87a480a",
  "ComfyUI_essentials": "33ff89fd354d8ec3ab6affb605a79a931b445d99"
}
```

After:
```json
{
  "ComfyUI-disty-Flow": "aba029a46c60b0493ddd46a8a9ad3c2e0b501cd5",
  "ComfyUI-Manager": "6fee2b8b106c47804bfd7d3ff3f49704f3369ab5",
  "comfyui-easy-use": "1.2.5", <-----
  "ComfyUI_devtools": "b9ce1265b3786da85812adcc97c8421ef87a480a",
  "ComfyUI_essentials": "33ff89fd354d8ec3ab6affb605a79a931b445d99"
}
```