### PR TITLE
[CNR] Remove `@<version>` suffix on module name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ github-stats-cache.json
 pip_overrides.json
 *.json
 check2.sh
+/venv/

--- a/cm-cli.py
+++ b/cm-cli.py
@@ -224,7 +224,7 @@ def fix_node(node_spec_str, is_all=False, cnt_msg=''):
         print(f"ERROR: f{res.msg}")
 
 
-def uninstall_node(node_spec_str, is_all=False, cnt_msg=''):
+def uninstall_node(node_spec_str: str, is_all: bool = False, cnt_msg: str = ''):
     spec = node_spec_str.split('@')
     if len(spec) == 2 and spec[1] == 'unknown':
         node_name = spec[0]

--- a/git_helper.py
+++ b/git_helper.py
@@ -437,35 +437,6 @@ def setup_environment():
         git.Git().update_environment(GIT_PYTHON_GIT_EXECUTABLE=config['default']['git_exe'])
 
 
-def is_git_repo(path: str) -> bool:
-    """ Check if the path is a git repository. """
-    try:
-        # Try to create a Repo object from the path
-        _ = git.Repo(path).git_dir
-        return True
-    except git.exc.InvalidGitRepositoryError:
-        return False
-
-
-def get_commit_hash(fullpath):
-    git_head = os.path.join(fullpath, '.git', 'HEAD')
-    if os.path.exists(git_head):
-        with open(git_head) as f:
-            line = f.readline()
-
-            if line.startswith("ref: "):
-                ref = os.path.join(fullpath, '.git', line[5:].strip())
-                if os.path.exists(ref):
-                    with open(ref) as f2:
-                        return f2.readline().strip()
-                else:
-                    return "unknown"
-            else:
-                return line
-
-    return "unknown"
-
-
 setup_environment()
 
 

--- a/git_helper.py
+++ b/git_helper.py
@@ -437,6 +437,16 @@ def setup_environment():
         git.Git().update_environment(GIT_PYTHON_GIT_EXECUTABLE=config['default']['git_exe'])
 
 
+def is_git_repo(path: str) -> bool:
+    """ Check if the path is a git repository. """
+    try:
+        # Try to create a Repo object from the path
+        _ = git.Repo(path).git_dir
+        return True
+    except git.exc.InvalidGitRepositoryError:
+        return False
+
+
 setup_environment()
 
 
@@ -467,5 +477,5 @@ try:
 except Exception as e:
     print(e)
     sys.exit(-1)
-    
-    
+
+

--- a/git_helper.py
+++ b/git_helper.py
@@ -206,7 +206,7 @@ def checkout_custom_node_hash(git_custom_node_infos):
         repo_name_to_url[repo_name] = url
 
     for path in os.listdir(working_directory):
-        if '@' in path or path.endswith("ComfyUI-Manager"):
+        if path.endswith("ComfyUI-Manager"):
             continue
 
         fullpath = os.path.join(working_directory, path)
@@ -445,6 +445,25 @@ def is_git_repo(path: str) -> bool:
         return True
     except git.exc.InvalidGitRepositoryError:
         return False
+
+
+def get_commit_hash(fullpath):
+    git_head = os.path.join(fullpath, '.git', 'HEAD')
+    if os.path.exists(git_head):
+        with open(git_head) as f:
+            line = f.readline()
+
+            if line.startswith("ref: "):
+                ref = os.path.join(fullpath, '.git', line[5:].strip())
+                if os.path.exists(ref):
+                    with open(ref) as f2:
+                        return f2.readline().strip()
+                else:
+                    return "unknown"
+            else:
+                return line
+
+    return "unknown"
 
 
 setup_environment()

--- a/glob/git_utils.py
+++ b/glob/git_utils.py
@@ -1,0 +1,32 @@
+import os
+
+import git
+
+
+def is_git_repo(path: str) -> bool:
+    """ Check if the path is a git repository. """
+    try:
+        # Try to create a Repo object from the path
+        _ = git.Repo(path).git_dir
+        return True
+    except git.exc.InvalidGitRepositoryError:
+        return False
+
+
+def get_commit_hash(fullpath):
+    git_head = os.path.join(fullpath, '.git', 'HEAD')
+    if os.path.exists(git_head):
+        with open(git_head) as f:
+            line = f.readline()
+
+            if line.startswith("ref: "):
+                ref = os.path.join(fullpath, '.git', line[5:].strip())
+                if os.path.exists(ref):
+                    with open(ref) as f2:
+                        return f2.readline().strip()
+                else:
+                    return "unknown"
+            else:
+                return line
+
+    return "unknown"

--- a/glob/manager_core.py
+++ b/glob/manager_core.py
@@ -806,6 +806,7 @@ class UnifiedManager:
 
         zip_url = node_info.download_url
         from_path = self.active_nodes[node_id][1]
+        # PTAL(@ltdrdata): how to redesign and drop version_spec here?
         target = f"{node_id}@{version_spec.replace('.', '_')}"
         to_path = os.path.join(get_default_custom_nodes_path(), target)
 
@@ -873,6 +874,7 @@ class UnifiedManager:
                     os.rmdir(x)
 
         # 5. rename dir name <node_id>@<prev_ver> ==> <node_id>@<cur_ver>
+        # PTAL(@ltdrdata): how to redesign and drop version_spec here
         new_install_path = os.path.join(get_default_custom_nodes_path(), f"{node_id}@{version_spec.replace('.', '_')}")
         print(f"'{install_path}' is moved to '{new_install_path}'")
         shutil.move(install_path, new_install_path)
@@ -954,6 +956,7 @@ class UnifiedManager:
 
             from_path = cnr_info[version_spec]
             base_path = extract_base_custom_nodes_dir(from_path)
+            # PTAL(@ltdrdata): how to redesign and drop version_spec here
             to_path = os.path.join(base_path, f"{node_id}@{version_spec.replace('.', '_')}")
 
         if from_path is None or not os.path.exists(from_path):
@@ -1015,6 +1018,7 @@ class UnifiedManager:
             return result.fail(f'Specified active node not exists: {node_id}')
 
         base_path = extract_base_custom_nodes_dir(ver_and_path[1])
+        # PTAL(@ltdrdata): how to redesign and drop version_spec here
         to_path = os.path.join(base_path, '.disabled', f"{node_id}@{ver_and_path[0].replace('.', '_')}")
         shutil.move(ver_and_path[1], to_path)
         result.append((ver_and_path[1], to_path))
@@ -1105,6 +1109,7 @@ class UnifiedManager:
             os.remove(download_path)
 
         # install_path
+        # PTAL(@ltdrdata): how to redesign and drop version_spec here
         install_path = os.path.join(get_default_custom_nodes_path(), f"{node_id}@{version_spec.replace('.', '_')}")
         if os.path.exists(install_path):
             return result.fail(f'Install path already exists: {install_path}')
@@ -1291,6 +1296,7 @@ class UnifiedManager:
             if version_spec == 'unknown':
                 to_path = os.path.abspath(os.path.join(get_default_custom_nodes_path(), node_id))    # don't attach @unknown
             else:
+                # PTAL(@ltdrdata): how to redesign and drop version_spec here
                 to_path = os.path.abspath(os.path.join(get_default_custom_nodes_path(), f"{node_id}@{version_spec.replace('.', '_')}"))
             res = self.repo_install(repo_url, to_path, instant_execution=instant_execution, no_deps=no_deps, return_postinstall=return_postinstall)
             if res.result:

--- a/glob/manager_server.py
+++ b/glob/manager_server.py
@@ -544,37 +544,12 @@ def populate_markdown(x):
 
 @routes.get("/customnode/installed")
 async def installed_list(request):
-    result = {}
-    for x in folder_paths.get_folder_paths('custom_nodes'):
-        for module_name in os.listdir(x):
-            if (
-                module_name.endswith('.disabled') or
-                module_name == '__pycache__' or
-                module_name.endswith('.py') or
-                module_name.endswith('.example') or
-                module_name.endswith('.pyc')
-            ):
-                continue
+    unified_manager = core.unified_manager
 
-            spec = module_name.split('@')
-
-            if len(spec) == 2:
-                node_package_name = spec[0]
-                ver = spec[1].replace('_', '.')
-
-                if ver == 'nightly':
-                    ver = None
-            else:
-                node_package_name = module_name
-                ver = None
-
-            # extract commit hash
-            if ver is None:
-                ver = core.get_commit_hash(os.path.join(x, node_package_name))
-
-            result[node_package_name] = ver
-
-    return web.json_response(result, content_type='application/json')
+    return web.json_response({
+        node_id: package.version if package.is_from_cnr else package.get_commit_hash()
+        for node_id, package in unified_manager.installed_node_packages.items()
+    }, content_type='application/json')
 
 
 @routes.get("/customnode/getlist")

--- a/glob/node_package.py
+++ b/glob/node_package.py
@@ -5,7 +5,7 @@ import os
 
 import toml
 
-from git_helper import is_git_repo
+from git_helper import is_git_repo, get_commit_hash
 
 
 @dataclass
@@ -36,6 +36,15 @@ class InstalledNodePackage:
     @property
     def is_disabled(self) -> bool:
         return self.disabled
+
+    def get_commit_hash(self) -> str:
+        return get_commit_hash(self.fullpath)
+
+    def isValid(self) -> bool:
+        if self.is_from_cnr:
+            return os.path.exists(os.path.join(self.fullpath, '.tracking'))
+
+        return True
 
     @staticmethod
     def from_fullpath(fullpath: str) -> InstalledNodePackage:

--- a/glob/node_package.py
+++ b/glob/node_package.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+import os
+
+import toml
+
+from git_helper import is_git_repo
+
+
+@dataclass
+class InstalledNodePackage:
+    """Information about an installed node package."""
+
+    id: str
+    fullpath: str
+    disabled: bool
+    version: str
+
+    @property
+    def is_unknown(self) -> bool:
+        return self.version == "unknown"
+
+    @property
+    def is_nightly(self) -> bool:
+        return self.version == "nightly"
+
+    @property
+    def is_from_cnr(self) -> bool:
+        return not self.is_unknown and not self.is_nightly
+
+    @property
+    def is_enabled(self) -> bool:
+        return not self.disabled
+
+    @property
+    def is_disabled(self) -> bool:
+        return self.disabled
+
+    @staticmethod
+    def from_fullpath(fullpath: str) -> InstalledNodePackage:
+        parent_folder_name = os.path.split(fullpath)[-2]
+        module_name = os.path.basename(fullpath)
+        pyproject_toml_path = os.path.join(fullpath, "pyproject.toml")
+
+        if module_name.endswith(".disabled"):
+            node_id = module_name[:-9]
+            disabled = True
+        elif parent_folder_name == ".disabled":
+            # Nodes under custom_nodes/.disabled/* are disabled
+            node_id = module_name
+            disabled = True
+        else:
+            node_id = module_name
+            disabled = False
+
+        if is_git_repo(fullpath):
+            version = "nightly"
+        elif os.path.exists(pyproject_toml_path):
+            # Read project.toml to get the version
+            with open(pyproject_toml_path, "r", encoding="utf-8") as f:
+                pyproject_toml = toml.load(f)
+                # Fallback to 'unknown' if project.version doesn't exist
+                version = pyproject_toml.get("project", {}).get("version", "unknown")
+        else:
+            version = "unknown"
+
+        return InstalledNodePackage(
+            id=node_id, fullpath=fullpath, disabled=disabled, version=version
+        )

--- a/glob/node_package.py
+++ b/glob/node_package.py
@@ -5,7 +5,7 @@ import os
 
 import toml
 
-from git_helper import is_git_repo, get_commit_hash
+from git_utils import is_git_repo, get_commit_hash
 
 
 @dataclass

--- a/js/workflow-metadata.js
+++ b/js/workflow-metadata.js
@@ -47,7 +47,7 @@ class WorkflowMetadataExtension {
       const modules = nodeData.python_module.split(".");
 
       if (modules[0] === "custom_nodes") {
-        const nodePackageName = modules[1].split("@")[0];
+        const nodePackageName = modules[1];
         const nodeVersion = this.installedNodeVersions[nodePackageName];
         nodeVersions[nodePackageName] = nodeVersion;
       } else if (["nodes", "comfy_extras"].includes(modules[0])) {

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ huggingface-hub>0.20
 typer
 rich
 typing-extensions
+toml


### PR DESCRIPTION
The biggest issue on the `<node>@<version>` folder (module) name is that it breaks all imports of that module using the un-suffixed name. There are plenty of such usage in the wild that cannot be easily fixed.

![image](https://github.com/user-attachments/assets/ac8c6a4e-5fcc-4edc-9c54-d5fb12416f0b)

This PR removes the `@<version>` suffix from module name.

WIP (Needs verification from @ltdrdata)
The cache/switching version system needs a redesign.