### PR TITLE
cm-cli.py :specify commit ID /tag or branch when installing nodes and add 'exit-on-fail' parameter to control failure behavior

### DIFF
--- a/cm-cli.py
+++ b/cm-cli.py
@@ -200,15 +200,22 @@ class Ctx:
 
 cm_ctx = Ctx()
 
+def parse_node(node: str):
+    if '@@' in node:
+        name, commit = node.split('@@', 1)
+    else:
+        name, commit = node, None
+    return name, commit
 
 def install_node(node_name, is_all=False, cnt_msg=''):
+    node_name, commit_id = parse_node(node_name)
     if core.is_valid_url(node_name):
         # install via urls
-        res = core.gitclone_install([node_name])
+        res = core.gitclone_install([node_name],commits = [commit_id])
         if not res:
             print(f"[bold red]ERROR: An error occurred while installing '{node_name}'.[/bold red]")
         else:
-            print(f"{cnt_msg} [INSTALLED] {node_name:50}")
+            print(f"{cnt_msg} [INSTALLED] {node_name:50} => {commit_id}")
     else:
         node_path, node_item = cm_ctx.lookup_node_path(node_name)
 
@@ -218,11 +225,11 @@ def install_node(node_name, is_all=False, cnt_msg=''):
         elif os.path.exists(node_path + '.disabled'):
             enable_node(node_name)
         else:
-            res = core.gitclone_install(node_item['files'], instant_execution=True, msg_prefix=f"[{cnt_msg}] ")
+            res = core.gitclone_install(node_item['files'], instant_execution=True, msg_prefix=f"[{cnt_msg}] ", commits=[commit_id])
             if not res:
                 print(f"[bold red]ERROR: An error occurred while installing '{node_name}'.[/bold red]")
             else:
-                print(f"{cnt_msg} [INSTALLED] {node_name:50}")
+                print(f"{cnt_msg} [INSTALLED] {node_name:50} => {commit_id}")
 
 
 def reinstall_node(node_name, is_all=False, cnt_msg=''):

--- a/glob/manager_core.py
+++ b/glob/manager_core.py
@@ -584,9 +584,16 @@ def is_valid_url(url):
     return False
 
 
-def gitclone_install(files, instant_execution=False, msg_prefix=''):
-    print(f"{msg_prefix}Install: {files}")
-    for url in files:
+def gitclone_install(files, instant_execution=False, msg_prefix='', commits=None):
+    print(f"{msg_prefix}Install: {files}:{commits}")
+    if commits is None:
+        commits = [None] * len(files)
+    
+    if len(files) != len(commits):
+        print("Error: The number of files and commit IDs must match.")
+        return False
+
+    for url, commit_id in zip(files, commits):
         if not is_valid_url(url):
             print(f"Invalid git url: '{url}'")
             return False
@@ -605,6 +612,15 @@ def gitclone_install(files, instant_execution=False, msg_prefix=''):
                     return False
             else:
                 repo = git.Repo.clone_from(url, repo_path, recursive=True, progress=GitProgress())
+                if commit_id:
+                    print(f"Checkout commit: {commit_id}")
+                    try:
+                        # Try checking out as a commit, branch, or tag
+                        repo.git.checkout(commit_id)
+                    except Exception as checkout_error:
+                        print(f"Error checking out {commit_id}: {checkout_error}")
+                        return False
+
                 repo.git.clear_cache()
                 repo.close()
 


### PR DESCRIPTION
- **Details**:
- The `@@` delimiter allows users to specify a specific commit ID, tag, or branch for the node installation.
- This feature enhances flexibility by enabling users to install nodes from specific versions of a repository.
- Add 'exit-on-fail' parameter to control failure behavior

- **Example**:
- Install a node from a specific branch:
  ```
  python3 cm-cli.py install git@github.com:evanspearman/ComfyMath.git@@main
  ```
- Install a node from a specific tag:
  ```
  python3 cm-cli.py install https://github.com/Nourepide/ComfyUI-Allor.git@@v1.0.0
  ```
- Install a node from a specific commit ID:
  ```
  python3 cm-cli.py install git@github.com:evanspearman/ComfyMath.git@@2ee689
  ```
- The `exit_on_fail` parameter determines whether the process should exit when an action fails.
   ```
    python3 cm-cli.py install --exit-on-fail git@github.com:evanspearman/ComfyMath.git@@rag https://github.com/Nourepide/ComfyUI-Allor.git@@2ee689
   ```

- **Impact**:
This change improves the usability of the `cm-cli.py` script by allowing users to install nodes from specific versions of repositories, rather than always using the default branch. Parameter '--exit-on-fail' enhances the flexibility of the cm-cli.py by allowing users to control the behavior when an action fails, without forcing an immediate exit.