### PR TITLE
fix: remove the unsafe models, these models are vulnerable to threat(s) PAIT-PYTCH-100.

### DIFF
--- a/model-list.json
+++ b/model-list.json
@@ -2040,50 +2040,6 @@
       "size": "22.5MB"
     },
     {
-      "name": "person_yolov8m (segm)",
-      "type": "Ultralytics",
-      "base": "Ultralytics",
-      "save_path": "ultralytics/segm",
-      "description": "These are the available models in the UltralyticsDetectorProvider of Impact Pack.",
-      "reference": "https://huggingface.co/Bingsu/adetailer/tree/main",
-      "filename": "person_yolov8m-seg.pt",
-      "url": "https://huggingface.co/Bingsu/adetailer/resolve/main/person_yolov8m-seg.pt",
-      "size": "54.8MB"
-    },
-    {
-      "name": "person_yolov8n (segm)",
-      "type": "Ultralytics",
-      "base": "Ultralytics",
-      "save_path": "ultralytics/segm",
-      "description": "These are the available models in the UltralyticsDetectorProvider of Impact Pack.",
-      "reference": "https://huggingface.co/Bingsu/adetailer/tree/main",
-      "filename": "person_yolov8n-seg.pt",
-      "url": "https://huggingface.co/Bingsu/adetailer/resolve/main/person_yolov8n-seg.pt",
-      "size": "6.78MB"
-    },
-    {
-      "name": "person_yolov8s (segm)",
-      "type": "Ultralytics",
-      "base": "Ultralytics",
-      "save_path": "ultralytics/segm",
-      "description": "These are the available models in the UltralyticsDetectorProvider of Impact Pack.",
-      "reference": "https://huggingface.co/Bingsu/adetailer/tree/main",
-      "filename": "person_yolov8s-seg.pt",
-      "url": "https://huggingface.co/Bingsu/adetailer/resolve/main/person_yolov8s-seg.pt",
-      "size": "23.9MB"
-    },
-    {
-      "name": "deepfashion2_yolov8s (segm)",
-      "type": "Ultralytics",
-      "base": "Ultralytics",
-      "save_path": "ultralytics/segm",
-      "description": "These are the available models in the UltralyticsDetectorProvider of Impact Pack.",
-      "reference": "https://huggingface.co/Bingsu/adetailer/tree/main",
-      "filename": "deepfashion2_yolov8s-seg.pt",
-      "url": "https://huggingface.co/Bingsu/adetailer/resolve/main/deepfashion2_yolov8s-seg.pt",
-      "size": "23.9MB"
-    },
-    {
       "name": "face_yolov8m-seg_60.pt (segm)",
       "type": "Ultralytics",
       "base": "Ultralytics",


### PR DESCRIPTION
## Model Security

Temporarily remove the following unsafe model files. These models are vulnerable to threat(s) [PAIT-PYTCH-100](https://protectai.com/insights/knowledge-base/deserialization-threats/PAIT-PYTCH-100).

- deepfashion2_yolov8s-seg.pt   [Hugging Face Scan Report](https://protectai.com/insights/models/Bingsu/adetailer/53cc19de382014514d9d4038601d261a7faa9b7b/files?blob-id=513307f6ae53bd57946ff5c4af897563bd8f0ad6&utm_source=huggingface&threat=PAIT-PYTCH-100)
- person_yolov8m-seg.pt   [Hugging Face Scan Report](https://protectai.com/insights/models/Bingsu/adetailer/53cc19de382014514d9d4038601d261a7faa9b7b/files?blob-id=7b072e035e0c72e7b62767f4ba6d53be332da820&utm_source=huggingface&threat=PAIT-PYTCH-100)
- person_yolov8n-seg.pt   [Hugging Face Scan Report](https://protectai.com/insights/models/Bingsu/adetailer/53cc19de382014514d9d4038601d261a7faa9b7b/files?blob-id=80660e6d831b21d59921975308fbee02e4de52ea&utm_source=huggingface&threat=PAIT-PYTCH-100)
- person_yolov8s-seg.pt   [Hugging Face Scan Report](https://protectai.com/insights/models/Bingsu/adetailer/53cc19de382014514d9d4038601d261a7faa9b7b/files?blob-id=c7c75982f5bafd5168267ad7a7dccbbc234d3af1&utm_source=huggingface&threat=PAIT-PYTCH-100)

