### PR TITLE
revise /customnode/installed api

### DIFF
--- a/glob/cnr_utils.py
+++ b/glob/cnr_utils.py
@@ -144,7 +144,7 @@ def generate_cnr_id(fullpath, cnr_id):
 def read_cnr_id(fullpath):
     cnr_id_path = os.path.join(fullpath, '.git', '.cnr-id')
     try:
-        if not os.path.exists(cnr_id_path):
+        if os.path.exists(cnr_id_path):
             with open(cnr_id_path) as f:
                 return f.read().strip()
     except:

--- a/glob/cnr_utils.py
+++ b/glob/cnr_utils.py
@@ -129,3 +129,26 @@ def read_cnr_info(fullpath):
         return None
     except Exception:
         return None  # not valid CNR node pack
+
+
+def generate_cnr_id(fullpath, cnr_id):
+    cnr_id_path = os.path.join(fullpath, '.git', '.cnr-id')
+    try:
+        if not os.path.exists(cnr_id_path):
+            with open(cnr_id_path, "w") as f:
+                return f.write(cnr_id)
+    except:
+        print(f"[ComfyUI Manager] unable to create file: {cnr_id_path}")
+
+
+def read_cnr_id(fullpath):
+    cnr_id_path = os.path.join(fullpath, '.git', '.cnr-id')
+    try:
+        if not os.path.exists(cnr_id_path):
+            with open(cnr_id_path) as f:
+                return f.read().strip()
+    except:
+        pass
+
+    return None
+

--- a/glob/manager_core.py
+++ b/glob/manager_core.py
@@ -1396,6 +1396,24 @@ def identify_node_pack_from_path(fullpath):
             return module_name, commit_hash, ''
 
 
+def get_installed_node_packs():
+    res = {}
+
+    for x in get_custom_nodes_paths():
+        for y in os.listdir(x):
+            if y == '__pycache__' or y.endswith('.disabled'):
+                continue
+
+            fullpath = os.path.join(x, y)
+            info = identify_node_pack_from_path(fullpath)
+            if info is None:
+                continue
+
+            res[info[0]] = [info[1], info[2]]
+
+    return res
+
+
 def get_channel_dict():
     global channel_dict
 

--- a/glob/manager_core.py
+++ b/glob/manager_core.py
@@ -1,3 +1,8 @@
+"""
+description:
+    `manager_core` contains the core implementation of the management functions in ComfyUI-Manager.
+"""
+
 import json
 import os
 import sys
@@ -36,7 +41,7 @@ import manager_downloader
 from node_package import InstalledNodePackage
 
 
-version_code = [3, 3, 10]
+version_code = [3, 3, 11]
 version_str = f"V{version_code[0]}.{version_code[1]}" + (f'.{version_code[2]}' if len(version_code) > 2 else '')
 
 
@@ -177,6 +182,10 @@ def update_user_directory(user_dir):
     manager_channel_list_path = os.path.join(manager_files_path, 'channels.list')
     manager_pip_overrides_path = os.path.join(manager_files_path, "pip_overrides.json")
     manager_components_path = os.path.join(manager_files_path, "components")
+    manager_util.cache_dir = os.path.join(manager_files_path, "cache")
+
+    if not os.path.exists(manager_util.cache_dir):
+        os.makedirs(manager_util.cache_dir)
 
 try:
     import folder_paths

--- a/glob/manager_core.py
+++ b/glob/manager_core.py
@@ -1428,7 +1428,7 @@ def get_installed_node_packs():
                 if y == '__pycache__':
                     continue
 
-                fullpath = os.path.join(x, y)
+                fullpath = os.path.join(disabled_dirs, y)
                 info = identify_node_pack_from_path(fullpath)
                 if info is None:
                     continue

--- a/glob/manager_core.py
+++ b/glob/manager_core.py
@@ -1410,7 +1410,7 @@ def get_installed_node_packs():
 
     for x in get_custom_nodes_paths():
         for y in os.listdir(x):
-            if y == '__pycache__' or y.endswith('.disabled'):
+            if y == '__pycache__' or y == '.disabled':
                 continue
 
             fullpath = os.path.join(x, y)
@@ -1418,7 +1418,22 @@ def get_installed_node_packs():
             if info is None:
                 continue
 
-            res[info[0]] = [info[1], info[2]]
+            is_disabled = not y.endswith('.disabled')
+
+            res[info[0]] = { 'ver': info[1], 'cnr_id': info[2], 'enabled': is_disabled }
+
+        disabled_dirs = os.path.join(x, '.disabled')
+        if os.path.exists(disabled_dirs):
+            for y in os.listdir(disabled_dirs):
+                if y == '__pycache__':
+                    continue
+
+                fullpath = os.path.join(x, y)
+                info = identify_node_pack_from_path(fullpath)
+                if info is None:
+                    continue
+
+                res[info[0]] = { 'ver': info[1], 'cnr_id': info[2], 'enabled': False }
 
     return res
 

--- a/glob/manager_server.py
+++ b/glob/manager_server.py
@@ -539,15 +539,21 @@ def populate_markdown(x):
 
 @routes.get("/customnode/installed")
 async def installed_list(request):
-    unified_manager = core.unified_manager
+    res = {}
 
-    await unified_manager.reload('cache')
-    await unified_manager.get_custom_nodes('default', 'cache')
+    for x in core.get_custom_nodes_paths():
+        for y in os.listdir(x):
+            if y == '__pycache__' or y.endswith('.disabled'):
+                continue
 
-    return web.json_response({
-        node_id: package.version if package.is_from_cnr else package.get_commit_hash()
-        for node_id, package in unified_manager.installed_node_packages.items() if not package.disabled
-    }, content_type='application/json')
+            fullpath = os.path.join(x, y)
+            info = core.identify_node_pack_from_path(fullpath)
+            if info is None:
+                continue
+
+            res[info[0]] = [info[1], info[2]]
+
+    return web.json_response(res, content_type='application/json')
 
 
 @routes.get("/customnode/getlist")

--- a/glob/manager_server.py
+++ b/glob/manager_server.py
@@ -537,21 +537,16 @@ def populate_markdown(x):
         x['title'] = manager_util.sanitize_tag(x['title'])
 
 
+# freeze imported version
+startup_time_installed_node_packs = core.get_installed_node_packs()
 @routes.get("/customnode/installed")
 async def installed_list(request):
-    res = {}
+    mode = request.query.get('mode', 'default')
 
-    for x in core.get_custom_nodes_paths():
-        for y in os.listdir(x):
-            if y == '__pycache__' or y.endswith('.disabled'):
-                continue
-
-            fullpath = os.path.join(x, y)
-            info = core.identify_node_pack_from_path(fullpath)
-            if info is None:
-                continue
-
-            res[info[0]] = [info[1], info[2]]
+    if mode == 'imported':
+        res = startup_time_installed_node_packs
+    else:
+        res = core.get_installed_node_packs()
 
     return web.json_response(res, content_type='application/json')
 

--- a/glob/manager_server.py
+++ b/glob/manager_server.py
@@ -1401,7 +1401,6 @@ async def default_cache_update():
     # else:
     #     logging.info("[ComfyUI-Manager] Migration check is skipped...")
 
-
 threading.Thread(target=lambda: asyncio.run(default_cache_update())).start()
 
 if not os.path.exists(core.manager_config_path):

--- a/glob/manager_util.py
+++ b/glob/manager_util.py
@@ -1,3 +1,8 @@
+"""
+description:
+    `manager_util` is the lightest module shared across the prestartup_script, main code, and cm-cli of ComfyUI-Manager.
+"""
+
 import aiohttp
 import json
 import threading
@@ -10,7 +15,7 @@ import re
 cache_lock = threading.Lock()
 
 comfyui_manager_path = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
-cache_dir = os.path.join(comfyui_manager_path, '.cache')
+cache_dir = os.path.join(comfyui_manager_path, '.cache')  # This path is also updated together in **manager_core.update_user_directory**.
 
 
 # DON'T USE StrictVersion - cannot handle pre_release version

--- a/js/workflow-metadata.js
+++ b/js/workflow-metadata.js
@@ -17,16 +17,18 @@ import { api } from "../../scripts/api.js";
 class WorkflowMetadataExtension {
   constructor() {
     this.name = "Comfy.CustomNodesManager.WorkflowMetadata";
-    this.installedNodeVersions = {};
+    this.installedNodes = {};
     this.comfyCoreVersion = null;
   }
 
   /**
-   * Get the installed node versions
-   * @returns {Promise<Record<string, string>>} The mapping from node name to version
-   * version can either be a git commit hash or a semantic version such as "1.0.0"
+   * Get the installed nodes info
+   * @returns {Promise<Record<string, {ver: string, cnr_id: string, enabled: boolean}>>} The mapping from node name to its info.
+   * ver can either be a git commit hash or a semantic version such as "1.0.0"
+   * cnr_id is the id of the node in the ComfyRegistry
+   * enabled is true if the node is enabled, false if it is disabled
    */
-  async getInstalledNodeVersions() {
+  async getInstalledNodes() {
     const res = await api.fetchApi("/customnode/installed");
     return await res.json();
   }
@@ -48,8 +50,10 @@ class WorkflowMetadataExtension {
 
       if (modules[0] === "custom_nodes") {
         const nodePackageName = modules[1];
-        const nodeVersion = this.installedNodeVersions[nodePackageName];
-        nodeVersions[nodePackageName] = nodeVersion;
+        const nodeInfo =
+          this.installedNodes[nodePackageName] ??
+          this.installedNodes[nodePackageName.toLowerCase()];
+        nodeVersions[nodePackageName] = nodeInfo.ver;
       } else if (["nodes", "comfy_extras"].includes(modules[0])) {
         nodeVersions["comfy-core"] = this.comfyCoreVersion;
       } else {
@@ -61,7 +65,7 @@ class WorkflowMetadataExtension {
 
   async init() {
     const extension = this;
-    this.installedNodeVersions = await this.getInstalledNodeVersions();
+    this.installedNodes = await this.getInstalledNodes();
     this.comfyCoreVersion = (await api.getSystemStats()).system.comfyui_version;
 
     // Attach metadata when app.graphToPrompt is called.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "comfyui-manager"
 description = "ComfyUI-Manager provides features to install and manage custom nodes for ComfyUI, as well as various functionalities to assist with ComfyUI."
-version = "3.3.10"
+version = "3.4"
 license = { file = "LICENSE.txt" }
 dependencies = ["GitPython", "PyGithub", "matrix-client==0.4.0", "transformers", "huggingface-hub>0.20", "typer", "rich", "typing-extensions"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "comfyui-manager"
 description = "ComfyUI-Manager provides features to install and manage custom nodes for ComfyUI, as well as various functionalities to assist with ComfyUI."
-version = "3.3.10"
+version = "3.3.11"
 license = { file = "LICENSE.txt" }
 dependencies = ["GitPython", "PyGithub", "matrix-client==0.4.0", "transformers", "huggingface-hub>0.20", "typer", "rich", "typing-extensions"]
 


### PR DESCRIPTION
improved: don't fetch data from cnr for the api
improved: change format `{<cnr id>: <version>} -> {<module>: {'ver': <version>, 'cnr_id': <cnr id>, 'enabled': <enable/disable status>}}`
improved: add `mode=imported` for startup snapshot
* `/customnode/installed` - current snapshot
* `/customnode/installed?mode=imported` - startup snapshot

example:
```
{
      "ComfyUI-GGUF": { // unknown
        "ver": "3dc384b23366983b28222cbf681b808053949a43",
        "cnr_id": "",
        "enabled": true
      }, 
      "comfyui-impact-pack": {  // nightly
        "ver": "12e838a3209202f4fbe06f1af8607cb1417560f5",
        "cnr_id": "comfyui-impact-pack",
        "enabled": true
      },
      "comfyui_layerstyle": {  // cnr
        "ver": "1.0.90",
        "cnr_id": "comfyui_layerstyle",
        "enabled": true
      },
      "comfyui-supir@nightly": { // disabled
        "ver": "53fc4f82f139e0875e1f4f3716fbeafa073e4242",
        "cnr_id": "comfyui-supir",
        "enabled": false
      },
}

```