### PR TITLE
Fix missing image in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ In `ComfyUI-Manager` V3.0 and later, configuration files and dynamically generat
 
 ## Support of missing nodes installation
 
-![missing-menu](https://raw.githubusercontent.com/ltdrdata/ComfyUI-extension-tutorials/Main/ComfyUI-Manager/images/missing-dialog.jpg)
+![missing-menu](https://raw.githubusercontent.com/ltdrdata/ComfyUI-extension-tutorials/Main/ComfyUI-Manager/images/missing-menu.jpg)
 
 * When you click on the ```Install Missing Custom Nodes``` button in the menu, it displays a list of extension nodes that contain nodes not currently present in the workflow.
 


### PR DESCRIPTION
Resolves a slight mismatch in the URL of one of the images in the README:

![image](https://github.com/user-attachments/assets/b20a657b-caf3-40ea-a91f-79781e4d6cf5)

PR updates URL to match the alt-text.