### PR TITLE
Use requests library to resolve SSL errors.

### DIFF
--- a/glob/manager_core.py
+++ b/glob/manager_core.py
@@ -893,7 +893,7 @@ class UnifiedManager:
 
         archive_name = f"CNR_temp_{str(uuid.uuid4())}.zip"  # should be unpredictable name - security precaution
         download_path = os.path.join(get_default_custom_nodes_path(), archive_name)
-        manager_downloader.download_url(node_info.download_url, get_default_custom_nodes_path(), archive_name)
+        manager_downloader.basic_download_url(node_info.download_url, get_default_custom_nodes_path(), archive_name)
 
         # 2. extract files into <node_id>
         install_path = self.active_nodes[node_id][1]

--- a/glob/manager_downloader.py
+++ b/glob/manager_downloader.py
@@ -16,7 +16,11 @@ if aria2 is not None:
     aria2 = aria2p.API(aria2p.Client(host=host, port=port, secret=secret))
 
 
-def basic_download_url(url, dest_folder, filename):
+def basic_download_url(url, dest_folder: str, filename: str):
+    '''
+    Download file from url to dest_folder with filename
+    using requests library.
+    '''
     import requests
 
     # Ensure the destination folder exists


### PR DESCRIPTION
Was getting some errors when installing custom nodes from registry on macOS: 

```
  File "/Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/urllib/request.py", line 1347, in do_open
    raise URLError(err)
urllib.error.URLError: <urlopen error [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer certificate (_ssl.c:1000)>
^C
```

Currently, we use torchvision's util download function, which uses urllib3 to download files from a URL. However, that library only uses CPython's default bundled trusted certs which are not always complete. The `requests`library uses `certifi` by default and I was able to resolve this issue by switching to it.

Ref: https://requests.readthedocs.io/en/latest/user/advanced/#ca-certificates
```
Requests uses certificates from the package [certifi](https://certifiio.readthedocs.io/).
```