### PR TITLE
add ComfyLab-Pack to custom-node-list.json

### DIFF
--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -16498,7 +16498,7 @@
             ],
             "install_type": "git-clone",
             "description": "This repository provides utility nodes for defining inputs and outputs in ComfyUI workflows. These nodes are essential for running ShellAgent apps with ComfyUI, but they can also be used independently to specify input/output variables and their requirements explicitly."
-        },  
+        },
         {
             "author": "Vrch Studio (vrch.ai)",
             "title": "ComfyUI Web Viewer",
@@ -18140,7 +18140,7 @@
             "install_type": "git-clone"
         },
         {
-            "author": "magic-quill", 
+            "author": "magic-quill",
             "title": "ComfyUI_MagicQuill",
             "id": "MagicQuill",
             "reference": "https://github.com/magic-quill/ComfyUI_MagicQuill",
@@ -19835,7 +19835,7 @@
 
 
 
-        
+
 
         {
             "author": "Ser-Hilary",
@@ -20247,6 +20247,18 @@
             ],
             "install_type": "unzip",
             "description": "This is a node to convert an image into a CMYK Halftone dot image."
+        },
+        {
+            "author": "bugltd",
+            "title": "ComfyLab Pack",
+            "id": "comfylab-pack",
+            "reference": "https://github.com/bugltd/ComfyLab-Pack",
+            "files": [
+                "https://github.com/bugltd/ComfyLab-Pack"
+            ],
+            "nodename_pattern": " \\(lab\\)$",
+            "install_type": "git-clone",
+            "description": "Nodes: XY Plot with many options, Output Config (JSON / JSON5 / YAML), Queue, Format String, List utilities, Input nodes, ...."
         }
     ]
 }


### PR DESCRIPTION
Hello,

Humbly requesting your review, to include my extension `ComfyLab Pack` into the ComfyUI Manager registry.

As requested, I checked everything is fine by switching to `DB: Local`.
The extension is also already published to the Comfy Registry: [link](https://registry.comfy.org/nodes/comfylab-pack).

[Comprehensive node list in wiki](https://github.com/bugltd/ComfyLab-Pack/blob/more_wiki/wiki/node_list.md) (branch not merged yet, but very soon)

Thanks in advance for your help.

Edit 1: node list added in wiki