### PR TITLE
Fix import collision

### DIFF
--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -20174,7 +20174,7 @@
         {
             "author": "ProGamerGov",
             "title": "PyTorch 360° Image Conversion Toolkit for ComfyUI",
-            "id": "pytorch360convert",
+            "id": "ComfyUI-pytorch360convert",
             "reference": "https://github.com/ProGamerGov/ComfyUI_pytorch360convert",
             "files": [
                 "https://github.com/ProGamerGov/ComfyUI_pytorch360convert"

--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -20174,7 +20174,7 @@
         {
             "author": "ProGamerGov",
             "title": "PyTorch 360° Image Conversion Toolkit for ComfyUI",
-            "id": "ComfyUI-pytorch360convert",
+            "id": "comfyui-pytorch360convert",
             "reference": "https://github.com/ProGamerGov/ComfyUI_pytorch360convert",
             "files": [
                 "https://github.com/ProGamerGov/ComfyUI_pytorch360convert"


### PR DESCRIPTION
Currently the extension directory and dependency have the same name, and that leads to errors when trying to load it.

This PR fixes the issue.