### PR TITLE
Add commands to toggle visibility of manager and custom nodes manager menus

### DIFF
--- a/js/comfyui-manager.js
+++ b/js/comfyui-manager.js
@@ -1409,7 +1409,7 @@ app.registerExtension({
       function: () => {
         if (!manager_instance) {
           setManagerInstance(new ManagerMenuDialog());
-					manager_instance.show();
+          manager_instance.show();
         } else {
           manager_instance.toggleVisibility();
         }

--- a/js/comfyui-manager.js
+++ b/js/comfyui-manager.js
@@ -1277,7 +1277,7 @@ class ManagerMenuDialog extends ComfyDialog {
 	}
 
 	toggleVisibility() {
-		if(this.isVisible) {
+		if (this.isVisible) {
 			this.close();
 		} else {
 			this.show();

--- a/js/comfyui-manager.js
+++ b/js/comfyui-manager.js
@@ -1276,13 +1276,9 @@ class ManagerMenuDialog extends ComfyDialog {
 		this.element.style.display = "block";
 	}
 
-	hide() {
-		this.element.style.display = "none";
-	}
-
 	toggleVisibility() {
 		if(this.isVisible) {
-			this.hide();
+			this.close();
 		} else {
 			this.show();
 		}

--- a/js/comfyui-manager.js
+++ b/js/comfyui-manager.js
@@ -1269,7 +1269,7 @@ class ManagerMenuDialog extends ComfyDialog {
 	}
 
 	get isVisible() {
-		return this.element?.style?.display === "block";
+		return this.element?.style?.display !== "none";
 	}
 
 	show() {

--- a/js/comfyui-manager.js
+++ b/js/comfyui-manager.js
@@ -1268,8 +1268,24 @@ class ManagerMenuDialog extends ComfyDialog {
 		this.element = $el("div.comfy-modal", { id:'cm-manager-dialog', parent: document.body }, [ content ]);
 	}
 
+	get isVisible() {
+		return this.element?.style?.display === "block";
+	}
+
 	show() {
 		this.element.style.display = "block";
+	}
+
+	hide() {
+		this.element.style.display = "none";
+	}
+
+	toggleVisibility() {
+		if(this.isVisible) {
+			this.hide();
+		} else {
+			this.show();
+		}
 	}
 
 	handleWorkflowGalleryButtonClick(e) {
@@ -1388,6 +1404,41 @@ app.registerExtension({
 			icon: 'pi pi-th-large'
 		}
 	],
+
+  commands: [
+    {
+      id: "Comfy.Manager.Menu.ToggleVisibility",
+      label: "Toggle Manager Menu Visibility",
+      icon: "mdi mdi-puzzle",
+      function: () => {
+        if (!manager_instance) {
+          setManagerInstance(new ManagerMenuDialog());
+					manager_instance.show();
+        } else {
+          manager_instance.toggleVisibility();
+        }
+      },
+    },
+    {
+      id: "Comfy.Manager.CustomNodesManager.ToggleVisibility",
+      label: "Toggle Custom Nodes Manager Visibility",
+      icon: "pi pi-server",
+      function: () => {
+        if (CustomNodesManager.instance?.isVisible) {
+          CustomNodesManager.instance.close();
+          return;
+        }
+
+        if (!manager_instance) {
+          setManagerInstance(new ManagerMenuDialog());
+        }
+        if (!CustomNodesManager.instance) {
+          CustomNodesManager.instance = new CustomNodesManager(app, self);
+        }
+        CustomNodesManager.instance.show(CustomNodesManager.ShowMode.NORMAL);
+      },
+    },
+  ],
 
 	init() {
 		$el("style", {

--- a/js/custom-nodes-manager.js
+++ b/js/custom-nodes-manager.js
@@ -1916,4 +1916,8 @@ export class CustomNodesManager {
 	close() {
 		this.element.style.display = "none";
 	}
+
+	get isVisible() {
+		return this.element?.style?.display === "flex";
+	}
 }

--- a/js/custom-nodes-manager.js
+++ b/js/custom-nodes-manager.js
@@ -1918,6 +1918,6 @@ export class CustomNodesManager {
 	}
 
 	get isVisible() {
-		return this.element?.style?.display === "flex";
+		return this.element?.style?.display !== "none";
 	}
 }


### PR DESCRIPTION
This PR adds a `commands` field to the `Comfy.ManagerMenu` extension containing commands to toggle visibility of the manager menu and custom nodes manager menu. This allows these actions to be bound to keybindings or used by other extensions.


https://github.com/user-attachments/assets/aff1ec2f-2043-47fb-b3ba-623f9f8cf9e9

Feel free to write to this PR, or close and open with alternative implementation. Thanks.