### PR TITLE
Add optional error reporting for custom node installation and import errors

### DIFF
--- a/js/common.js
+++ b/js/common.js
@@ -95,61 +95,61 @@ function internalCustomConfirm(message, confirmMessage, cancelMessage) {
 }
 
 export function addReportButton(dialogEl, options = {}) {
-  const contentEl = dialogEl.querySelector(".comfy-modal-content");
-  const closeBtnEl = contentEl?.querySelector("button");
-  if (!contentEl || !closeBtnEl) return;
+	const contentEl = dialogEl.querySelector(".comfy-modal-content");
+	const closeBtnEl = contentEl?.querySelector("button");
+	if (!contentEl || !closeBtnEl) return;
 
-  const { msg, errorSubtype, extraFields = [] } = options;
+	const { msg, errorSubtype, extraFields = [] } = options;
 
-  const button = document.createElement("button");
-  button.textContent = "Report Error";
-  button.style.marginBottom = "0.25rem"; // mt-1
+	const button = document.createElement("button");
+	button.textContent = "Report Error";
+	button.style.marginBottom = "0.25rem"; // mt-1
 
-  const cleanText = (text) => (text ? text.replace(/[\r\n\t\s]/g, " ") : text);
+	const cleanText = (text) => (text ? text.replace(/[\r\n\t\s]/g, " ") : text);
 
-  button.addEventListener("click", () => {
-    window["app"].extensionManager.dialog.showIssueReportDialog({
-      title: "Report Manager Issue",
-      subtitle: "Please describe the issue you are experiencing",
-      panelProps: {
-        errorType: "ManagerError",
-        exceptionMessage: cleanText(msg),
-        tags: {
-          errorSubtype: cleanText(errorSubtype),
-          isElectron: "electronAPI" in window,
-        },
-        defaultFields: ["Logs", "SystemStats"],
-        extraFields: [
-          {
-            label: "ComfyUI-Manager Version",
-            value: "ManagerVersion", // unique ID for the field
-            getData: async () =>
-              (await api.fetchApi(`/manager/version`)).text(),
-          },
-          ...extraFields,
-        ],
-      },
-    });
-    button.remove();
-  });
+	button.addEventListener("click", () => {
+		window["app"].extensionManager.dialog.showIssueReportDialog({
+			title: "Report Manager Issue",
+			subtitle: "Please describe the issue you are experiencing",
+			panelProps: {
+				errorType: "ManagerError",
+				exceptionMessage: cleanText(msg),
+				tags: {
+					errorSubtype: cleanText(errorSubtype),
+					isElectron: "electronAPI" in window,
+				},
+				defaultFields: ["Logs", "SystemStats"],
+				extraFields: [
+					{
+						label: "ComfyUI-Manager Version",
+						value: "ManagerVersion", // unique ID for the field
+						getData: async () =>
+							(await api.fetchApi(`/manager/version`)).text(),
+					},
+					...extraFields,
+				],
+			},
+		});
+		button.remove();
+	});
 
-  closeBtnEl.addEventListener("click", () => button.remove(), {
-    once: true,
-    passive: true,
-  });
-  contentEl.insertBefore(button, closeBtnEl);
+	closeBtnEl.addEventListener("click", () => button.remove(), {
+		once: true,
+		passive: true,
+	});
+	contentEl.insertBefore(button, closeBtnEl);
 }
 
 export function show_message(msg, errorReportOptions) {
-  app.ui.dialog.show(msg);
-  if (errorReportOptions) {
-    try {
-      addReportButton(app.ui.dialog.element, errorReportOptions);
-    } catch {
-      // do nothing
-    }
-  }
-  app.ui.dialog.element.style.zIndex = 1100;
+	app.ui.dialog.show(msg);
+	if (errorReportOptions) {
+		try {
+			addReportButton(app.ui.dialog.element, errorReportOptions);
+		} catch {
+			// do nothing
+		}
+	}
+	app.ui.dialog.element.style.zIndex = 1100;
 }
 
 export async function sleep(ms) {

--- a/js/common.js
+++ b/js/common.js
@@ -94,9 +94,62 @@ function internalCustomConfirm(message, confirmMessage, cancelMessage) {
 	});
 }
 
-export function show_message(msg) {
-	app.ui.dialog.show(msg);
-	app.ui.dialog.element.style.zIndex = 1100;
+export function addReportButton(dialogEl, options = {}) {
+  const contentEl = dialogEl.querySelector(".comfy-modal-content");
+  const closeBtnEl = contentEl?.querySelector("button");
+  if (!contentEl || !closeBtnEl) return;
+
+  const { msg, errorSubtype, extraFields = [] } = options;
+
+  const button = document.createElement("button");
+  button.textContent = "Report Error";
+  button.style.marginBottom = "0.25rem"; // mt-1
+
+  const cleanText = (text) => (text ? text.replace(/[\r\n\t\s]/g, " ") : text);
+
+  button.addEventListener("click", () => {
+    window["app"].extensionManager.dialog.showIssueReportDialog({
+      title: "Report Manager Issue",
+      subtitle: "Please describe the issue you are experiencing",
+      panelProps: {
+        errorType: "ManagerError",
+        exceptionMessage: cleanText(msg),
+        tags: {
+          errorSubtype: cleanText(errorSubtype),
+          isElectron: "electronAPI" in window,
+        },
+        defaultFields: ["Logs", "SystemStats"],
+        extraFields: [
+          {
+            label: "ComfyUI-Manager Version",
+            value: "ManagerVersion", // unique ID for the field
+            getData: async () =>
+              (await api.fetchApi(`/manager/version`)).text(),
+          },
+          ...extraFields,
+        ],
+      },
+    });
+    button.remove();
+  });
+
+  closeBtnEl.addEventListener("click", () => button.remove(), {
+    once: true,
+    passive: true,
+  });
+  contentEl.insertBefore(button, closeBtnEl);
+}
+
+export function show_message(msg, errorReportOptions) {
+  app.ui.dialog.show(msg);
+  if (errorReportOptions) {
+    try {
+      addReportButton(app.ui.dialog.element, errorReportOptions);
+    } catch {
+      // do nothing
+    }
+  }
+  app.ui.dialog.element.style.zIndex = 1100;
 }
 
 export async function sleep(ms) {

--- a/js/common.js
+++ b/js/common.js
@@ -103,7 +103,7 @@ export function addReportButton(dialogEl, options = {}) {
 
 	const button = document.createElement("button");
 	button.textContent = "Report Error";
-	button.style.marginBottom = "0.25rem"; // mt-1
+	button.style.marginBottom = "0.25rem";
 
 	const cleanText = (text) => (text ? text.replace(/[\r\n\t\s]/g, " ") : text);
 

--- a/js/custom-nodes-manager.js
+++ b/js/custom-nodes-manager.js
@@ -1471,17 +1471,17 @@ export class CustomNodesManager {
 
 		if (errorMsg) {
 			self.showError(errorMsg);
-      show_message("Installation Error:\n"+errorMsg, {
+			show_message("Installation Error:\n"+errorMsg, {
 				msg: `Installation Error: ${errorMsg}`,
-        errorSubtype: `node${label}Error`,
-        extraFields: [
-          {
-            label: `${label} Error Trace`,
-            value: `${label}ErrorsTrace`,
-            getData: () => errorMsg,
-          },
-        ],
-      });
+				errorSubtype: `node${label}Error`,
+				extraFields: [
+					{
+						label: `${label} Error Trace`,
+						value: `${label}ErrorsTrace`,
+						getData: () => errorMsg,
+					},
+				],
+			});
 		} else {
 			self.showStatus(`${label} ${result.length} custom node(s) successfully`);
 		}

--- a/js/custom-nodes-manager.js
+++ b/js/custom-nodes-manager.js
@@ -930,7 +930,17 @@ export class CustomNodesManager {
 			show_message(title+'The information is not available.')
 		}
 		else {
-			show_message(title+sanitizeHTML(res['msg']).replace(/ /g, '&nbsp;').replace(/\n/g, '<BR>'));
+			const errorReportOptions = {
+				msg: `Error importing '${rowItem.title}' module.`,
+				errorSubtype: "importError",
+				extraFields: [{
+					label: "Failed Import Info",
+					value: "FailedImportInfo",
+					getData: () => res['msg']
+				}],
+			}
+
+			show_message(title+sanitizeHTML(res['msg']).replace(/ /g, '&nbsp;').replace(/\n/g, '<BR>'), errorReportOptions);
 		}
 	}
 
@@ -1461,7 +1471,17 @@ export class CustomNodesManager {
 
 		if (errorMsg) {
 			self.showError(errorMsg);
-			show_message("Installation Error:\n"+errorMsg);
+      show_message("Installation Error:\n"+errorMsg, {
+				msg: `Installation Error: ${errorMsg}`,
+        errorSubtype: `node${label}Error`,
+        extraFields: [
+          {
+            label: `${label} Error Trace`,
+            value: `${label}ErrorsTrace`,
+            getData: () => errorMsg,
+          },
+        ],
+      });
 		} else {
 			self.showStatus(`${label} ${result.length} custom node(s) successfully`);
 		}


### PR DESCRIPTION
This PR adds an option to attach a `Report Error` button to the dialog shown via `show_message`, which open an issue report panel with customizable fields.

![manager](https://github.com/user-attachments/assets/17cace55-bdab-4810-a228-73afeee64708)

Additional fields can be added to provide more context, and tags can be added to help categorize errors. Overall, this will help empirically quantify the frequency and and nature of errors experienced by users.