### PR TITLE
Allow `vscode-merge-base` to appear multiple times in `.git/config`

### DIFF
--- a/glob/git_utils.py
+++ b/glob/git_utils.py
@@ -37,7 +37,8 @@ def git_url(fullpath):
     if not os.path.exists(git_config_path):
         return None
 
-    config = configparser.ConfigParser()
+    # Set `strict=False` to allow duplicate `vscode-merge-base` sections, addressing <https://github.com/ltdrdata/ComfyUI-Manager/issues/1529>
+    config = configparser.ConfigParser(strict=False)
     config.read(git_config_path)
 
     for k, v in config.items():


### PR DESCRIPTION
## Description
Fixes #1529 by allowing duplicate `vscode-merge-base` sections through ConfigParser(strict=False)

### Changes
- Set `strict=False` in [ConfigParser](https://github.com/ltdrdata/ComfyUI-Manager/blob/a6cc392473b1157f82f3088b97593d07e680c636/glob/git_utils.py#L40) instantiation