### PR TITLE
restart action: support running as Python module

### DIFF
--- a/glob/manager_server.py
+++ b/glob/manager_server.py
@@ -1578,6 +1578,9 @@ def restart(self):
 
     if sys.platform.startswith('win32'):
         cmds = ['"' + sys.executable + '"', '"' + sys_argv[0] + '"'] + sys_argv[1:]
+    elif sys_argv[0].endswith("__main__.py"):  # this is a python module
+        module_name = os.path.basename(os.path.dirname(sys_argv[0]))
+        cmds = [sys.executable, '-m', module_name] + sys_argv[1:]
     else:
         cmds = [sys.executable] + sys_argv
 


### PR DESCRIPTION
This little PR simply adds a check if the main python executable file has the name `__main__.py` - then the restart is performed via `python -m MODULE_NAME ...`, and not directly via the full path to "__main__.py", which leads to a `relative imports` error, since python modules always do relative imports within themselves.

This will allow us to use ComfyUI-Manager in future versions of Visionatrix, our project is launched by the line:

`python -m visionatrix`

With these changes, the restart works successfully, and these changes are not tied specifically to our project, but are universal, and may be useful to someone else in the future.