### PR TITLE
Add Force of Will Suite Light to custom-node-list.json for Beginner-Friendly ComfyUI Prompt Refinement

### DIFF
--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -21905,6 +21905,17 @@
             ],
             "install_type": "unzip",
             "description": "This is a node to convert an image into a CMYK Halftone dot image."
-        }
+        },
+        {
+  "author": "SirWillance",
+  "title": "Force of Will Suite Light",
+  "id": "fow-suite-light",
+  "reference": "https://github.com/SirWillance/FoW_Suite_LIGHT",
+  "files": [
+    "https://github.com/SirWillance/FoW_Suite_LIGHT"
+  ],
+  "install_type": "git-clone",
+  "description": "Beginner-friendly nodes for prompt refinement in ComfyUI, including custom nodes for weighting, splitting, combining, catalogues, and the PromptRefiner for a simple prompt interface. For more info, join me on https://www.twitch.tv/sirwillance. Be one of the first 50 followers to get a FREE upgrade to the Standard Tier!"
+}
     ]
 }

--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -21422,13 +21422,14 @@
         },
         {
             "author": "SirWillance",
-            "title": " FoW_Suite_LIGHT",
+            "title": "Force of Will Suite Light",
+            "id": "fow-suite-light",
             "reference": "https://github.com/SirWillance/FoW_Suite_LIGHT",
             "files": [
                 "https://github.com/SirWillance/FoW_Suite_LIGHT"
             ],
             "install_type": "git-clone",
-            "description": "oW_Suite_LIGHT is the beginner-friendly version of the 'FoW' (Force Of Will) suite for ComfyUI, featuring PromptRefinerLight as the flagship node for simple prompt creation. It helps low-spec users craft raw prompts and collaborate with high-spec users for image generation, with a light, stable design—no tokenization or weighing, perfect for newbies! I developed it as my first coding project in 2 months, learning ComfyUI’s capabilities along the way."
+            "description": "Beginner-friendly nodes for prompt refinement in ComfyUI, including custom nodes for weighting, splitting, combining, catalogues, and the PromptRefiner for a simple prompt interface. For more info, join me on https://www.twitch.tv/sirwillance. Be one of the first 50 followers to get a FREE upgrade to the Standard Tier!"
         },
         {
             "author": "KAVVATARE",
@@ -21905,17 +21906,6 @@
             ],
             "install_type": "unzip",
             "description": "This is a node to convert an image into a CMYK Halftone dot image."
-        },
-        {
-            "author": "SirWillance",
-            "title": "Force of Will Suite Light",
-            "id": "fow-suite-light",
-            "reference": "https://github.com/SirWillance/FoW_Suite_LIGHT",
-            "files": [
-            "https://github.com/SirWillance/FoW_Suite_LIGHT"
-            ],
-            "install_type": "git-clone",
-            "description": "Beginner-friendly nodes for prompt refinement in ComfyUI, including custom nodes for weighting, splitting, combining, catalogues, and the PromptRefiner for a simple prompt interface. For more info, join me on https://www.twitch.tv/sirwillance. Be one of the first 50 followers to get a FREE upgrade to the Standard Tier!"
         }
     ]
 }

--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -21907,15 +21907,15 @@
             "description": "This is a node to convert an image into a CMYK Halftone dot image."
         },
         {
-  "author": "SirWillance",
-  "title": "Force of Will Suite Light",
-  "id": "fow-suite-light",
-  "reference": "https://github.com/SirWillance/FoW_Suite_LIGHT",
-  "files": [
-    "https://github.com/SirWillance/FoW_Suite_LIGHT"
-  ],
-  "install_type": "git-clone",
-  "description": "Beginner-friendly nodes for prompt refinement in ComfyUI, including custom nodes for weighting, splitting, combining, catalogues, and the PromptRefiner for a simple prompt interface. For more info, join me on https://www.twitch.tv/sirwillance. Be one of the first 50 followers to get a FREE upgrade to the Standard Tier!"
-}
+            "author": "SirWillance",
+            "title": "Force of Will Suite Light",
+            "id": "fow-suite-light",
+            "reference": "https://github.com/SirWillance/FoW_Suite_LIGHT",
+            "files": [
+            "https://github.com/SirWillance/FoW_Suite_LIGHT"
+            ],
+            "install_type": "git-clone",
+            "description": "Beginner-friendly nodes for prompt refinement in ComfyUI, including custom nodes for weighting, splitting, combining, catalogues, and the PromptRefiner for a simple prompt interface. For more info, join me on https://www.twitch.tv/sirwillance. Be one of the first 50 followers to get a FREE upgrade to the Standard Tier!"
+        }
     ]
 }


### PR DESCRIPTION
This PR adds a beginner-friendly custom node suite for ComfyUI prompt refinement:

1. **Force of Will Suite Light** (ID: `fow-suite-light`):
   - Free, beginner-friendly nodes for prompt weighting, splitting, combining, catalogues, and PromptRefiner.
   - Uses predefined libraries, no customized tokens, designed for new users.
   - Promotes my Twitch channel (https://www.twitch.tv/sirwillance) for more info, offering a FREE upgrade to Standard Tier for the first 50 followers via Discord (https://discord.gg/BHSxf8HB).
   
The Suite is hosted on GitHub, use `install_type: git-clone`, and have no dependencies or conflicts with existing nodes. I’ve tested locally in ComfyUI Manager and verified they appear in “Install Custom Nodes.” Let me know if you need additional details or adjustments!