### PR TITLE
fix: "get_installed_packages" should return python packages names in lowercase

### DIFF
--- a/glob/manager_util.py
+++ b/glob/manager_util.py
@@ -246,7 +246,7 @@ def get_installed_packages(renew=False):
                     if y[0] == 'Package' or y[0].startswith('-'):
                         continue
 
-                    pip_map[y[0]] = y[1]
+                    pip_map[y[0].lower()] = y[1]
         except subprocess.CalledProcessError:
             logging.error("[ComfyUI-Manager] Failed to retrieve the information of installed pip packages.")
             return set()


### PR DESCRIPTION
According to PEP 503, package names are treated as case-insensitive.

The specification mandates that names are normalized (typically to lowercase) when compared or looked up.

Without this the new feature that introduced today: https://github.com/ltdrdata/ComfyUI-Manager/commit/e8c782c8e1f7200ccc921856f9bd513f5c28432b 

always re-installs the `SqlAlchemy` package(for example).

