### PR TITLE
small fix for running as py-module on windows

### DIFF
--- a/glob/manager_server.py
+++ b/glob/manager_server.py
@@ -1599,11 +1599,11 @@ def restart(self):
     if '--windows-standalone-build' in sys_argv:
         sys_argv.remove('--windows-standalone-build')
 
-    if sys.platform.startswith('win32'):
-        cmds = ['"' + sys.executable + '"', '"' + sys_argv[0] + '"'] + sys_argv[1:]
-    elif sys_argv[0].endswith("__main__.py"):  # this is a python module
+    if sys_argv[0].endswith("__main__.py"):  # this is a python module
         module_name = os.path.basename(os.path.dirname(sys_argv[0]))
         cmds = [sys.executable, '-m', module_name] + sys_argv[1:]
+    elif sys.platform.startswith('win32'):
+        cmds = ['"' + sys.executable + '"', '"' + sys_argv[0] + '"'] + sys_argv[1:]
     else:
         cmds = [sys.executable] + sys_argv
 

--- a/prestartup_script.py
+++ b/prestartup_script.py
@@ -816,11 +816,11 @@ if script_executed:
     else:
         sys_argv = sys.argv.copy()
 
-        if sys.platform.startswith('win32'):
-            cmds = ['"' + sys.executable + '"', '"' + sys_argv[0] + '"'] + sys_argv[1:]
-        elif sys_argv[0].endswith("__main__.py"):  # this is a python module
+        if sys_argv[0].endswith("__main__.py"):  # this is a python module
             module_name = os.path.basename(os.path.dirname(sys_argv[0]))
             cmds = [sys.executable, '-m', module_name] + sys_argv[1:]
+        elif sys.platform.startswith('win32'):
+            cmds = ['"' + sys.executable + '"', '"' + sys_argv[0] + '"'] + sys_argv[1:]
         else:
             cmds = [sys.executable] + sys_argv
 


### PR DESCRIPTION
In PR I simply changed the conditions for the code, for "python module" escaping is not important, so it can be first to not increase size of code.

I didn't notice then that there is a separate logic for Windows (_I wonder why? - Linux supports paths with `"`_) - and now that we have successfully switched to ComfyUI-Manager! test actions on Windows are starting to fail :(

P.S.: I saw another strange log string: I constantly see the text `'comfyui-frontend-package' dependency were fixed` - since the package name is actually `comfyui_frontend_package` and code checks for `comfyui-frontend-package` - should I create an issue and ask you whether to fix this or not (this is the same PEP 503, where `-` and `_` are equal in names) - or should I just open PRs right away?