### PR TITLE
set channel=default, mode=cache for git clone

### DIFF
--- a/glob/manager_core.py
+++ b/glob/manager_core.py
@@ -2098,7 +2098,7 @@ async def gitclone_install(url, instant_execution=False, msg_prefix='', no_deps=
         cnr = unified_manager.get_cnr_by_repo(url)
         if cnr:
             cnr_id = cnr['id']
-            return await unified_manager.install_by_id(cnr_id, version_spec='nightly')
+            return await unified_manager.install_by_id(cnr_id, version_spec='nightly', channel="default", mode="cache")
         else:
             repo_name = os.path.splitext(os.path.basename(url))[0]
 


### PR DESCRIPTION
Related to https://github.com/ltdrdata/ComfyUI-Manager/issues/1651#issuecomment-2720360147

I'm not sure if this is the correct fix, but judging by the code above, at the start of `gitclone_install` function - it is assumed that `channel=default` and `mode=cache`

That's why I set them to be passed to `unified_manager.install_by_id` - from what I understand of the code, that's how it should be (but I could be wrong, I'm still figuring out this idea of ​​different channels)