### PR TITLE
Add LoadImageFromHttpURL node by jerrywap

### DIFF
--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -23494,6 +23494,17 @@
         },
         {
             "author": "jerrywap",
+            "title": "ComfyUI_LoadImageFromHttpURL",
+            "id": "load-image-from-http-url",
+            "reference": "https://github.com/jerrywap/ComfyUI_LoadImageFromHttpURL",
+            "files": [
+              "https://github.com/jerrywap/ComfyUI_LoadImageFromHttpURL"
+            ],
+            "install_type": "git-clone",
+            "description": "A ComfyUI node that fetches an image from an HTTP URL and returns it as an image tensor. Useful for API-based workflows."
+         },
+        {
+            "author": "jerrywap",
             "title": "ComfyUI_UploadToWebhookHTTP",
             "id": "upload-to-webhook-http",
             "reference": "https://github.com/jerrywap/ComfyUI_UploadToWebhookHTTP",
@@ -23502,7 +23513,7 @@
             ],
             "install_type": "git-clone",
             "description": "Send generated images or videos to any HTTP webhook with optional parameters such as prompt-id and metadata payload."
-        },
+        },  
         {
             "author": "zouyu",
             "title": "ComfyUI-SaveImageS3",


### PR DESCRIPTION
Add LoadImageFromHttpURL node by jerrywap

## 🔍 Description

**Load Image from HTTP URL** is a lightweight but powerful custom node for ComfyUI that allows you to **fetch images directly from a remote URL** and use them in your workflows without manual uploads or preprocessing.

Instead of uploading an image file manually, you can pass a publicly accessible image URL — and the node will handle downloading, decoding, and converting it into an image tensor compatible with ComfyUI.

This is especially useful when you're:
- ⚙️ Building **ComfyUI as an API service**
- 📡 Receiving image URLs from client apps, webhooks, or JSON payloads
- 🌐 Working with **dynamic content** from external APIs or cloud storage

By skipping the file transfer step, you reduce friction, improve performance, and make your workflows more automation-friendly.
![image](https://github.com/user-attachments/assets/a4191f2c-70ec-4611-8bce-49d5a693b0b7)

