### PR TITLE
Only load legacy FE extension if `--enable-manager-legacy-ui` is set

### DIFF
--- a/comfyui_manager/__init__.py
+++ b/comfyui_manager/__init__.py
@@ -2,8 +2,6 @@ import os
 import logging
 from comfy.cli_args import args
 
-ENABLE_LEGACY_COMFYUI_MANAGER_FRONT_DEFAULT = True # Enable legacy ComfyUI Manager frontend while new UI is in beta phase
-
 def prestartup():
     from . import prestartup_script  # noqa: F401
     logging.info('[PRE] ComfyUI-Manager')
@@ -14,8 +12,7 @@ def start():
     from .common import cm_global     # noqa: F401
 
     if not args.disable_manager:
-        should_show_legacy_manager_front = args.enable_manager_legacy_ui or ENABLE_LEGACY_COMFYUI_MANAGER_FRONT_DEFAULT
-        if should_show_legacy_manager_front:
+        if args.enable_manager_legacy_ui:
             try:
                 from .legacy import manager_server  # noqa: F401
                 from .legacy import share_3rdparty  # noqa: F401

--- a/comfyui_manager/glob/manager_server.py
+++ b/comfyui_manager/glob/manager_server.py
@@ -991,6 +991,13 @@ def populate_markdown(x):
     if 'title' in x:
         x['title'] = manager_util.sanitize_tag(x['title'])
 
+@routes.get("/v2/manager/is_legacy_manager_ui")
+async def is_legacy_manager_ui(request):
+    return web.json_response(
+        {"is_legacy_manager_ui": args.enable_manager_legacy_ui},
+        content_type="application/json",
+        status=200,
+    )
 
 # freeze imported version
 startup_time_installed_node_packs = core.get_installed_node_packs()


### PR DESCRIPTION
Per discussion [here](https://github.com/Comfy-Org/ComfyUI-Manager/pull/1737#discussion_r2040723439), the frontend has been updated ([see preview](https://github.com/Comfy-Org/ComfyUI_frontend/pull/3367#issuecomment-2802441190)) to only offer the legacy UI if the `--enable-manager-legacy-ui` startup arg is set.