### PR TITLE
Change order of manager to be default install latest

### DIFF
--- a/js/custom-nodes-manager.js
+++ b/js/custom-nodes-manager.js
@@ -1410,14 +1410,15 @@ export class CustomNodesManager {
 			let version_cnt = 0;
 
 			if(!is_enable) {
+
+				if(rowItem.cnr_latest != rowItem.originalData.active_version && obj.length > 0) {
+					versions.push('latest');
+				}
+
 				if(rowItem.originalData.active_version != 'nightly') {
 					versions.push('nightly');
 					default_version = 'nightly';
 					version_cnt++;
-				}
-
-				if(rowItem.cnr_latest != rowItem.originalData.active_version && obj.length > 0) {
-					versions.push('latest');
 				}
 			}
 


### PR DESCRIPTION
This pull request includes a change to the `CustomNodesManager` class in the `js/custom-nodes-manager.js` file. The change involves reordering the logic for adding the 'latest' version to the `versions` array when `is_enable` is false.

Changes to version management logic:

* [`js/custom-nodes-manager.js`](diffhunk://#diff-b1fc64ca95489e049e680db92523b4f0e58d7a9376529f65475efe975ae21cd0R1413-L1421): Moved the condition to push 'latest' to the `versions` array before checking for the 'nightly' version when `is_enable` is false. This ensures that 'latest' is added to the array before 'nightly' if applicable.