### PR TITLE
Add `is_legacy_manager_ui` route from the `legacy` package as well

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -5,3 +5,9 @@ include LICENSE.txt
 include README.md
 include requirements.txt
 include pyproject.toml
+include custom-node-list.json
+include extension-node-list.json
+include extras.json
+include github-stats.json
+include model-list.json
+include alter-list.json

--- a/comfyui_manager/legacy/manager_server.py
+++ b/comfyui_manager/legacy/manager_server.py
@@ -992,6 +992,15 @@ def populate_markdown(x):
         x['title'] = manager_util.sanitize_tag(x['title'])
 
 
+@routes.get("/v2/manager/is_legacy_manager_ui")
+async def is_legacy_manager_ui(request):
+    return web.json_response(
+        {"is_legacy_manager_ui": args.enable_manager_legacy_ui},
+        content_type="application/json",
+        status=200,
+    )
+
+
 # freeze imported version
 startup_time_installed_node_packs = core.get_installed_node_packs()
 @routes.get("/v2/customnode/installed")


### PR DESCRIPTION
Follow-up on https://github.com/Comfy-Org/ComfyUI-Manager/pull/1746: Add `is_legacy_manager_ui` route from the `legacy` package as well. Otherwise, it won't exist when the legacy manager is actually enabled, which defeats part of the purpose. 