### PR TITLE
Fix: line terminator included in `ver` property in workflow

### DIFF
--- a/js/workflow-metadata.js
+++ b/js/workflow-metadata.js
@@ -70,7 +70,7 @@ class WorkflowMetadataExtension {
         if (cnr_id === "comfy-core") return; // don't allow hijacking comfy-core name
         if (cnr_id) nodeProperties.cnr_id = cnr_id;
         else nodeProperties.aux_id = aux_id;
-        if (ver) nodeProperties.ver = ver;
+        if (ver) nodeProperties.ver = ver.trim();
       } else if (["nodes", "comfy_extras"].includes(moduleType)) {
         nodeProperties.cnr_id = "comfy-core";
         nodeProperties.ver = this.comfyCoreVersion;


### PR DESCRIPTION
Somehow, a line terminator (`\n`) is getting included in the `ver` field of a node pack in the workflow reported by user [here](https://github.com/comfyanonymous/ComfyUI/issues/7309#issuecomment-2814403190). 

Workflow: [Tagging.with.IF.Image.to.Prompt.json](https://github.com/user-attachments/files/19808328/Tagging.with.IF.Image.to.Prompt.json)

I can't determine how it might have happened, but adding `trim` seems appropriate either way.