### PR TITLE
add ModelQuantizer node to custom node list

### DIFF
--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -25606,6 +25606,17 @@
             ],
             "install_type": "unzip",
             "description": "This is a node to convert an image into a CMYK Halftone dot image."
+        },
+        {
+            "author": "lum3on",
+            "title": "ComfyUI Model Quantizer",
+            "id": "ModelQuantizer",
+            "reference": "https://github.com/lum3on/ComfyUI-ModelQuantizer",
+            "files": [
+                "https://github.com/lum3on/ComfyUI-ModelQuantizer/blob/main/nodes.py"
+            ],
+            "install_type": "unzip",
+            "description": "This is a node to converts models into Fp8, bf16, fp16."
         }
     ]
 }

--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -25613,9 +25613,9 @@
             "id": "ModelQuantizer",
             "reference": "https://github.com/lum3on/ComfyUI-ModelQuantizer",
             "files": [
-                "https://github.com/lum3on/ComfyUI-ModelQuantizer/blob/main/nodes.py"
+                "https://github.com/lum3on/ComfyUI-ModelQuantizer"
             ],
-            "install_type": "unzip",
+            "install_type": "git-clone",
             "description": "This is a node to converts models into Fp8, bf16, fp16."
         }
     ]


### PR DESCRIPTION
A custom node pack for ComfyUI that provides tools for quantizing model weights to lower precision formats like FP16, BF16, or true FP8 types.