### PR TITLE
Fix restore-dependencies requirements.txt parsing to handle inline comments

### DIFF
--- a/glob/manager_core.py
+++ b/glob/manager_core.py
@@ -868,8 +868,9 @@ class UnifiedManager:
                     package_name = remap_pip_package(line.strip())
                     if package_name and not package_name.startswith('#') and package_name not in self.processed_install:
                         self.processed_install.add(package_name)
-                        install_cmd = manager_util.make_pip_cmd(["install", package_name])
-                        if package_name.strip() != "" and not package_name.startswith('#'):
+                        clean_package_name = package_name.split('#')[0].strip()
+                        install_cmd = manager_util.make_pip_cmd(["install", clean_package_name])
+                        if clean_package_name != "" and not clean_package_name.startswith('#'):
                             res = res and try_install_script(url, repo_path, install_cmd, instant_execution=instant_execution)
 
                 pip_fixer.fix_broken()


### PR DESCRIPTION
## Issue Description
This PR fixes a bug in the `restore-dependencies` command that occurred when a package in `requirements.txt` had an inline comment after the package name. 

Previously, when executing `python cm-cli.py restore-dependencies`, the entire line (including comments) was passed to pip as the package name, causing installation failures. For example, a line like:

```
gdown # supports downloading the large file from Google Drive
```

Would result in the following error:

```
/home/x/x/ComfyUI/custom_nodes/ComfyUI-Manager/glob/manager_core.py:873 in execute_install_script               │
│                                                                                                                            │
│    870 │   │   │   │   │   │   self.processed_install.add(package_name)                                                    │
│    871 │   │   │   │   │   │   install_cmd = manager_util.make_pip_cmd(["install", package_name                            │
│    872 │   │   │   │   │   │   if package_name.strip() != "" and not package_name.startswith('#                            │
│ ❱  873 │   │   │   │   │   │   │   res = res and try_install_script(url, repo_path, install_cmd                            │
│    874 │   │   │   │                                                                                                       │
│    875 │   │   │   │   pip_fixer.fix_broken()                                                                              │
│    876                                                                                                                     │
│                                                                                                                            │
│ ╭───────────────────────────────────────────── locals ──────────────────────────────────────────────╮                      │
│ │         install_cmd = [                                                                           │                      │
│ │                       │   '/home/ubuntu/miniconda3/envs/comfy/bin/python',                        │                      │
│ │                       │   '-m',                                                                   │                      │
│ │                       │   'pip',                                                                  │                      │
│ │                       │   'install',                                                              │                      │
│ │                       │   'gdown # supports downloading the large file from Google Drive'         │                      │
│ │                       ]                                                                           │                      │
│ │ install_script_path = '/home/x/x/ComfyUI/custom_nodes/facerestore_cf/install.py'       │                      │
│ │   instant_execution = True                                                                        │                      │
│ │           lazy_mode = False                                                                       │                      │
│ │                line = 'gdown # supports downloading the large file from Google Drive\n'           │                      │
│ │               lines = [                                                                           │                      │
│ │                       │   'opencv-python\n',                                                      │                      │
│ │                       │   'numpy\n',                                                              │                      │
│ │                       │   'torch\n',                                                              │                      │
│ │                       │   'torchvision\n',                                                        │                      │
│ │                       │   'addict\n',                                                             │                      │
│ │                       │   'future\n',                                                             │                      │
│ │                       │   'lmdb\n',                                                               │                      │
│ │                       │   'Pillow\n',                                                             │                      │
│ │                       │   'pyyaml\n',                                                             │                      │
│ │                       │   'requests\n',                                                           │                      │
│ │                       │   ... +10                                                                 │                      │
│ │                       ]                                                                           │                      │
│ │             no_deps = False                                                                       │                      │
│ │        package_name = 'gdown # supports downloading the large file from Google Drive'             │                      │
│ │           pip_fixer = <manager_util.PIPFixer object at 0x7903308aa090>                            │                      │
│ │           repo_path = '/home/x/x/ComfyUI/custom_nodes/facerestore_cf'                  │                      │
│ │   requirements_path = '/home/x/x/ComfyUI/custom_nodes/facerestore_cf/requirements.txt' │                      │
│ │                 res = True                                                                        │                      │
│ │                self = <manager_core.UnifiedManager object at 0x79033033fbc0>                      │                      │
│ │                 url = ''                                                                          │                      │
│ ╰───────────────────────────────────────────────────────────────────────────────────────────────────╯               
```

This issue prevented the installation of several custom nodes, including the GGUF node.

## Solution
The fix adds proper parsing of package names by splitting at the `#` character and taking only the part before the comment. This ensures that only the actual package name is passed to pip during installation.

## Impact
This change allows for more flexible requirements.txt files that can include inline documentation while maintaining compatibility with pip's package specification format.
