### PR TITLE
Add NormalCrafterWrapper custom node by AIWarper

### DIFF
--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -25646,6 +25646,17 @@
             ],
             "install_type": "unzip",
             "description": "This is a node to convert an image into a CMYK Halftone dot image."
+        },
+        {
+            "author": "AIWarper",
+            "title": "NormalCrafterWrapper",
+            "id": "normal-crafter-wrapper",
+            "reference": "https://github.com/AIWarper/ComfyUI-NormalCrafterWrapper",
+            "files": [
+                "https://github.com/AIWarper/ComfyUI-NormalCrafterWrapper"
+            ],
+            "install_type": "git-clone",
+            "description": "ComfyUI diffusers wrapper nodes for [a/NormalCrafter](https://github.com/Binyr/NormalCrafter)"
         }
     ]
 }


### PR DESCRIPTION
This pull request adds the NormalCrafterWrapper custom node by AIWarper to the custom-node-list.json.

Node Details:

    Author: AIWarper

    Title: NormalCrafterWrapper

    ID: normal-crafter-wrapper

    Reference: https://github.com/AIWarper/ComfyUI-NormalCrafterWrapper

    Files: https://github.com/AIWarper/ComfyUI-NormalCrafterWrapper

    Install Type: git-clone

    Description: "ComfyUI diffusers wrapper nodes for [a/NormalCrafter](https://github.com/Binyr/NormalCrafter)"

Verification:

I have tested this addition locally by enabling the "Use local DB" option in ComfyUI-Manager settings. The custom node list loaded correctly, and the new entry for NormalCrafterWrapper appeared as expected without any JSON parsing errors.