### PR TITLE
Add inline comment to __init__.py

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,3 +1,6 @@
+```python
+# This file is the entry point for the ComfyUI-Manager package, handling CLI-only mode and initial setup.
+```
 import os
 import sys
 


### PR DESCRIPTION
Added an inline comment to __init__.py to improve code clarity.

Added an inline comment to `__init__.py` to clarify its role as the package entry point, improving code understanding.