### PR TITLE
Add Comfyui-BBoxLowerMask2 to custom-node-list.json

### DIFF
--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -24,6 +24,16 @@
             "preemptions":["SAMLoader"]
         },
         {
+            "author": "jqy-yo",
+            "title": "BBoxLowerMask2",
+            "reference": "https://github.com/jqy-yo/Comfyui-BBoxLowerMask2",
+            "files": [
+                "https://github.com/jqy-yo/Comfyui-BBoxLowerMask2"
+            ],
+            "install_type": "git-clone",
+            "description": "Create a mask to slice the image at specific coordinates"
+        },
+        {
             "author": "Dr.Lt.Data",
             "title": "ComfyUI Impact Subpack",
             "id": "comfyui-impact-subpack",


### PR DESCRIPTION
This PR adds a new custom node: [Comfyui-BBoxLowerMask2](https://github.com/jqy-yo/Comfyui-BBoxLowerMask2)

- Generates grayscale masks for facial parts using bounding boxes and keypoints.
- Supports toggling output for regions like eyes, nose, mouth, etc.
- Designed to be used in ComfyUI for facial region segmentation and blending.

I’ve verified that the custom-node-list loads correctly via "Use local DB" and no JSON errors are present.
