### PR TITLE
Feature/improve model manager viewing extra paths

### DIFF
--- a/glob/manager_server.py
+++ b/glob/manager_server.py
@@ -927,8 +927,6 @@ def check_model_installed(json_obj):
             model_dir_name = model_dir_name_map.get(item['type'].lower())
             full_paths = get_base_folder_path(model_dir_name, item['filename'], item['url'])
 
-            item['group'] = f"A"
-            
             # non-general name case
             if item['filename'] in total_models_files:
                 item['installed'] = 'True'
@@ -936,15 +934,12 @@ def check_model_installed(json_obj):
                 return
 
         if item['save_path'] == 'default':
-            item['group'] = 'B'
             model_dir_name = model_dir_name_map.get(item['type'].lower())
             if model_dir_name is not None:
                 item['installed'] = str(is_exists(model_dir_name, item['filename'], item['url']))
             else:
                 item['installed'] = 'False'
         else:
-            item['group'] = 'C'
-
             model_dir_name = item['save_path'].split('/')[0]
             if model_dir_name in folder_paths.folder_names_and_paths:
                 if is_exists(model_dir_name, item['filename'], item['url']):

--- a/glob/manager_server.py
+++ b/glob/manager_server.py
@@ -891,6 +891,21 @@ def check_model_installed(json_obj):
                 return True
 
         return False
+    
+    def get_base_folder_path(model_dir_name, filename, url):
+        if filename == '<huggingface>':
+            filename = os.path.basename(url)
+
+        dirs = folder_paths.get_folder_paths(model_dir_name)
+
+        results = []
+        for x in dirs:
+            full_path = os.path.join(x, filename)
+            if os.path.exists(full_path):
+                results.append(full_path)
+
+        return results
+    
 
     model_dir_names = ['checkpoints', 'loras', 'vae', 'text_encoders', 'diffusion_models', 'clip_vision', 'embeddings',
                        'diffusers', 'vae_approx', 'controlnet', 'gligen', 'upscale_models', 'hypernetworks',
@@ -902,19 +917,34 @@ def check_model_installed(json_obj):
             total_models_files.add(y)
 
     def process_model_phase(item):
+        def add_to_full_paths(path):
+            if 'full_paths' in item:
+                item['full_paths'].append(path)
+            else:
+                item['full_paths'] = [ path ]
+
         if 'diffusion' not in item['filename'] and 'pytorch' not in item['filename'] and 'model' not in item['filename']:
+            model_dir_name = model_dir_name_map.get(item['type'].lower())
+            full_paths = get_base_folder_path(model_dir_name, item['filename'], item['url'])
+
+            item['group'] = f"A"
+            
             # non-general name case
             if item['filename'] in total_models_files:
                 item['installed'] = 'True'
+                item['full_paths'] = full_paths
                 return
 
         if item['save_path'] == 'default':
+            item['group'] = 'B'
             model_dir_name = model_dir_name_map.get(item['type'].lower())
             if model_dir_name is not None:
                 item['installed'] = str(is_exists(model_dir_name, item['filename'], item['url']))
             else:
                 item['installed'] = 'False'
         else:
+            item['group'] = 'C'
+
             model_dir_name = item['save_path'].split('/')[0]
             if model_dir_name in folder_paths.folder_names_and_paths:
                 if is_exists(model_dir_name, item['filename'], item['url']):
@@ -937,7 +967,7 @@ def check_model_installed(json_obj):
 
                         if os.path.exists(fullpath):
                             item['installed'] = 'True'
-                            item['folder_path_source'] = base_path
+                            add_to_full_paths(fullpath)
 
     with concurrent.futures.ThreadPoolExecutor(8) as executor:
         for item in json_obj['models']:

--- a/glob/manager_server.py
+++ b/glob/manager_server.py
@@ -921,14 +921,23 @@ def check_model_installed(json_obj):
                     item['installed'] = 'True'
 
             if 'installed' not in item:
+                item['installed'] = 'False'
+
                 if item['filename'] == '<huggingface>':
                     filename = os.path.basename(item['url'])
                 else:
                     filename = item['filename']
 
-                fullpath = os.path.join(folder_paths.models_dir, item['save_path'], filename)
+                if model_dir_name in folder_paths.folder_names_and_paths:
+                    paths = folder_paths.folder_names_and_paths[model_dir_name][0]
 
-                item['installed'] = 'True' if os.path.exists(fullpath) else 'False'
+                    for folder_path in paths:
+                        base_path = os.path.split(folder_path)[0]
+                        fullpath = os.path.join(base_path, item['save_path'], filename)
+
+                        if os.path.exists(fullpath):
+                            item['installed'] = 'True'
+                            item['folder_path_source'] = base_path
 
     with concurrent.futures.ThreadPoolExecutor(8) as executor:
         for item in json_obj['models']:

--- a/js/model-manager.css
+++ b/js/model-manager.css
@@ -121,6 +121,10 @@
 	text-decoration: none;
 }
 
+.cmm-manager-grid .cmm-node-full-paths li {
+	overflow-wrap: break-word;
+}
+
 .cmm-manager-grid .tg-cell a:hover {
 	text-decoration: underline;
 }

--- a/js/model-manager.js
+++ b/js/model-manager.js
@@ -249,14 +249,14 @@ export class ModelManager {
 			bindContainerResize: true,
 
 			cellResizeObserver: (rowItem, columnItem) => {
-				const autoHeightColumns = ['name', 'description', 'folder_path_source'];
+				const autoHeightColumns = ['name', 'description', 'full_paths'];
 				return autoHeightColumns.includes(columnItem.id)
 			},
 
 			// updateGrid handler for filter and keywords
 			rowFilter: (rowItem) => {
 
-				const searchableColumns = ["name", "type", "base", "description", "filename", "save_path", "folder_path_source"];
+				const searchableColumns = ["name", "type", "base", "description", "filename", "save_path", "full_paths", "group"];
 				const models_extensions = ['.ckpt', '.pt', '.pt2', '.bin', '.pth', '.safetensors', '.pkl', '.sft'];
 
 				let shouldShown = grid.highlightKeywordsFilter(rowItem, searchableColumns, this.keywords);
@@ -382,11 +382,20 @@ export class ModelManager {
 			maxWidth: 5000,
 			classMap: 'cmm-node-desc'
 		}, {
-			id: 'folder_path_source',
-			name: 'Folder Path Source',
-			width: 400,
-			maxWidth: 5000,
-			classMap: 'cmm-node-desc'
+			id: 'full_paths',
+			name: 'Full Paths',
+			width: 200,
+			maxWidth: 2000,
+			classMap: 'cmm-node-full-paths',
+			formatter: (full_paths) => {
+				if (typeof full_paths === "object" && Array.isArray(full_paths)) {
+					const styled_full_paths = full_paths.map(path => '<li>' + path + '</li>').join("");
+
+					return `<ul>${styled_full_paths}</ul>`;
+				} else {
+					return full_paths;
+				}
+			}
 		}, {
 			id: "save_path",
 			name: 'Save Path',
@@ -394,6 +403,10 @@ export class ModelManager {
 		}, {
 			id: 'filename',
 			name: 'Filename',
+			width: 200
+		}, {
+			id: 'group',
+			name: 'Group',
 			width: 200
 		}];
 

--- a/js/model-manager.js
+++ b/js/model-manager.js
@@ -249,14 +249,14 @@ export class ModelManager {
 			bindContainerResize: true,
 
 			cellResizeObserver: (rowItem, columnItem) => {
-				const autoHeightColumns = ['name', 'description'];
+				const autoHeightColumns = ['name', 'description', 'folder_path_source'];
 				return autoHeightColumns.includes(columnItem.id)
 			},
 
 			// updateGrid handler for filter and keywords
 			rowFilter: (rowItem) => {
 
-				const searchableColumns = ["name", "type", "base", "description", "filename", "save_path"];
+				const searchableColumns = ["name", "type", "base", "description", "filename", "save_path", "folder_path_source"];
 				const models_extensions = ['.ckpt', '.pt', '.pt2', '.bin', '.pth', '.safetensors', '.pkl', '.sft'];
 
 				let shouldShown = grid.highlightKeywordsFilter(rowItem, searchableColumns, this.keywords);
@@ -378,6 +378,12 @@ export class ModelManager {
 		}, {
 			id: 'description',
 			name: 'Description',
+			width: 400,
+			maxWidth: 5000,
+			classMap: 'cmm-node-desc'
+		}, {
+			id: 'folder_path_source',
+			name: 'Folder Path Source',
 			width: 400,
 			maxWidth: 5000,
 			classMap: 'cmm-node-desc'

--- a/js/model-manager.js
+++ b/js/model-manager.js
@@ -256,7 +256,7 @@ export class ModelManager {
 			// updateGrid handler for filter and keywords
 			rowFilter: (rowItem) => {
 
-				const searchableColumns = ["name", "type", "base", "description", "filename", "save_path", "full_paths", "group"];
+				const searchableColumns = ["name", "type", "base", "description", "filename", "save_path", "full_paths"];
 				const models_extensions = ['.ckpt', '.pt', '.pt2', '.bin', '.pth', '.safetensors', '.pkl', '.sft'];
 
 				let shouldShown = grid.highlightKeywordsFilter(rowItem, searchableColumns, this.keywords);
@@ -382,6 +382,14 @@ export class ModelManager {
 			maxWidth: 5000,
 			classMap: 'cmm-node-desc'
 		}, {
+			id: "save_path",
+			name: 'Save Path',
+			width: 200
+		}, {
+			id: 'filename',
+			name: 'Filename',
+			width: 200
+		}, {
 			id: 'full_paths',
 			name: 'Full Paths',
 			width: 200,
@@ -396,18 +404,6 @@ export class ModelManager {
 					return full_paths;
 				}
 			}
-		}, {
-			id: "save_path",
-			name: 'Save Path',
-			width: 200
-		}, {
-			id: 'filename',
-			name: 'Filename',
-			width: 200
-		}, {
-			id: 'group',
-			name: 'Group',
-			width: 200
 		}];
 
 		restoreColumnWidth(gridId, columns);


### PR DESCRIPTION
PR for: https://github.com/Comfy-Org/ComfyUI-Manager/issues/1844

Added a new column for the model manager, `Full Paths`, which displays the full paths of installed models. Note that it bullet points each detected path if there are duplicate models installed in different model paths (via `extra_model_paths.yaml`).

This is helpful for model organization, if you specify many additional paths via `extra_model_paths.yaml`.

## Screenshots
<img width="1393" alt="Screenshot 2025-05-20 at 8 55 17 PM" src="https://github.com/user-attachments/assets/70314073-9ff5-4f51-b784-7dce6969b34e" />

<img width="1398" alt="Screenshot 2025-05-20 at 8 55 04 PM" src="https://github.com/user-attachments/assets/eaec383c-dd6c-4203-a837-5bc6e510a84f" />

<img width="1401" alt="Screenshot 2025-05-20 at 8 54 53 PM" src="https://github.com/user-attachments/assets/38680aa6-ace4-4b57-9865-936fd34650c2" />

My `extra_model_paths.yaml`:
<img width="622" alt="Screenshot 2025-05-20 at 10 03 04 PM" src="https://github.com/user-attachments/assets/a3bf7149-2d09-4b61-9800-5c0f71da51a6" />
