### PR TITLE
Add workaround for delay in link connection

### DIFF
--- a/js/node_fixer.js
+++ b/js/node_fixer.js
@@ -153,6 +153,7 @@ app.registerExtension({
 					app.canvas.graph.add(new_node, false);
 					node_info_copy(this, new_node, true);
 					app.canvas.graph.remove(this);
+					requestAnimationFrame(() => app.canvas.setDirty(true, true))
 				},
 			});
 		});


### PR DESCRIPTION
New input sockets have no pos, and require a render frame to occur before links can be set to the correct location.

- Resolves #1872