### PR TITLE
Add CAS Aspect Ratio Presets Node for ComfyUI to custom-node-list.json

### DIFF
--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -27569,6 +27569,17 @@
             ],
             "install_type": "unzip",
             "description": "This is a node to convert an image into a CMYK Halftone dot image."
+        },
+        {
+            "author": "budihartono",
+            "title": "CAS Aspect Ratio Presets Node for ComfyUI",
+            "id": "comfyui-aspect-ratio-presets",
+            "reference": "https://github.com/budihartono/comfyui-aspect-ratio-presets",
+            "files": [
+                "https://github.com/budihartono/comfyui-aspect-ratio-presets"
+            ],
+            "install_type": "git-clone",
+            "description": "Quickly create empty latents in common resolutions and aspect ratios for SD 1.5, SDXL, Flux, Chroma, and HiDream. Choose from curated presets or generate by axis and aspect ratio. Appears in the 'latent' node group."
         }
     ]
 }


### PR DESCRIPTION
Add a custom node to quickly create empty latents in common resolutions and aspect ratios for SD 1.5, SDXL, Flux, Chroma, and HiDream. Choose from curated presets or generate by axis and aspect ratio. Appears in the 'latent' node group.