### PR TITLE
Add Notification Bridge Node to Registry

### DIFF
--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -27639,6 +27639,16 @@
             ],
             "install_type": "unzip",
             "description": "This is a node to convert an image into a CMYK Halftone dot image."
+        },
+        {
+            "author": "INuBq8",
+            "title": "Notification Bridge",
+            "reference": "https://github.com/INuBq8/ComfyUI-NotificationBridge",
+            "files": [
+                        "https://github.com/INuBq8/ComfyUI-NotificationBridge"
+            ],
+            "install_type": "git_clone",
+            "description": "Bridge nodes for ComfyUI that send messages through WhatsApp (Twilio) and Discord when a workflow completes."
         }
     ]
 }


### PR DESCRIPTION
add small and lightweight notification bridge nodes that send notifications to WhatsApp or a Discord server.