### PR TITLE
fix(Windows, numpy): do not use 'uv' by default

### DIFF
--- a/glob/manager_core.py
+++ b/glob/manager_core.py
@@ -1745,7 +1745,7 @@ def read_config():
             'http_channel_enabled': False,
             'preview_method': manager_funcs.get_current_preview_method(),
             'git_exe': '',
-            'use_uv': manager_util.use_uv,
+            'use_uv': manager_util.use_uv and platform.system() != "Windows",  # temporary disable on Windows by default
             'channel_url': DEFAULT_CHANNEL,
             'default_cache_as_channel_url': False,
             'share_option': 'all',


### PR DESCRIPTION
Fixes: #1969

This only affects new installations, which is why so few people have had trouble with this problem (for now)

As a quick solution, I suggest not enabling `uv` by default **for Windows**.
Those who want still can enable it in config as before.