### PR TITLE
fix(Windows, numpy): fix for `cm-cli` usage

### DIFF
--- a/glob/manager_core.py
+++ b/glob/manager_core.py
@@ -1739,13 +1739,14 @@ def read_config():
 
     except Exception:
         import importlib.util
-        manager_util.use_uv = importlib.util.find_spec("uv") is not None
+        # temporary disable `uv` on Windows by default (https://github.com/Comfy-Org/ComfyUI-Manager/issues/1969)
+        manager_util.use_uv = importlib.util.find_spec("uv") is not None and platform.system() != "Windows"
         
         return {
             'http_channel_enabled': False,
             'preview_method': manager_funcs.get_current_preview_method(),
             'git_exe': '',
-            'use_uv': manager_util.use_uv and platform.system() != "Windows",  # temporary disable on Windows by default
+            'use_uv': manager_util.use_uv,
             'channel_url': DEFAULT_CHANNEL,
             'default_cache_as_channel_url': False,
             'share_option': 'all',


### PR DESCRIPTION
Follow up: #1971

Unfortunately, I was not so attentive and checked, only basic use with this through ComfiUI which previous PR fixed successfully.

But if we install Comfy-Manager and without running Comfy do `cm-cli.py install ..` when there is no Comfy-Manager config yet - then `uv` continues to be used, as `manager_util.use_uv` get initialized before line I changed, and `cm-cli.py` usage does not initialize config in the file if it is missing.

This small PR fixes that, sorry for disruption.