### PR TITLE
Add Comfy Contact Sheet Image Loader to custom nodes

### DIFF
--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -29400,6 +29400,17 @@
             ],
             "install_type": "git-clone",
             "description": "A powerful suite of nodes for ComfyUI to dynamically load prompts and images. This pack is especially focused on   batch processing from a directory and includes two main nodes: Advanced Prompt & Image Loader (Multiple) and   Advanced Prompt & Image Loader (single)."
+        },
+        {
+            "author": "voltans-voice-coach",
+            "description": "Displays up to 64 recent images from a folder as numbered thumbnails in a grid contact sheet format, allowing you to select and load one for post-processing",
+            "files": [
+                "https://github.com/benstaniford/comfy-contact-sheet-image-loader"
+            ],
+            "id": "comfy-contact-sheet-image-loader",
+            "install_type": "git-clone",
+            "reference": "https://github.com/benstaniford/comfy-contact-sheet-image-loader",
+            "title": "Comfy Contact Sheet Image Loader"
         }
     ]
 }


### PR DESCRIPTION
A custom ComfyUI node that displays up to 64 recent images from a folder as numbered thumbnails in a flexible grid contact sheet format, allowing you to easily select and load one of them for post-processing.

https://github.com/benstaniford/comfy-contact-sheet-image-loader?tab=readme-ov-file

![3vlfrsw7spbf1](https://github.com/user-attachments/assets/df120b4f-fa16-4ec8-a2cf-72841c02a0ca)
