### PR TITLE
Add LTX-Video 0.9.8 distilled models

### DIFF
--- a/model-list.json
+++ b/model-list.json
@@ -5148,6 +5148,50 @@
       "size": "15.7GB"
     },
     {
+      "name": "LTX-Video 2B Distilled v0.9.8",
+      "type": "checkpoint",
+      "base": "LTX-Video",
+      "save_path": "checkpoints/LTXV",
+      "description": "LTX-Video 2B distilled model v0.9.8 with improved prompt understanding and detail generation.",
+      "reference": "https://huggingface.co/Lightricks/LTX-Video",
+      "filename": "ltxv-2b-0.9.8-distilled.safetensors",
+      "url": "https://huggingface.co/Lightricks/LTX-Video/resolve/main/ltxv-2b-0.9.8-distilled.safetensors",
+      "size": "6.34GB"
+    },
+    {
+      "name": "LTX-Video 2B Distilled FP8 v0.9.8",
+      "type": "checkpoint",
+      "base": "LTX-Video",
+      "save_path": "checkpoints/LTXV",
+      "description": "Quantized LTX-Video 2B distilled model v0.9.8 with improved prompt understanding and detail generation, optimized for lower VRAM usage.",
+      "reference": "https://huggingface.co/Lightricks/LTX-Video",
+      "filename": "ltxv-2b-0.9.8-distilled-fp8.safetensors",
+      "url": "https://huggingface.co/Lightricks/LTX-Video/resolve/main/ltxv-2b-0.9.8-distilled-fp8.safetensors",
+      "size": "4.46GB"
+    },
+    {
+      "name": "LTX-Video 13B Distilled v0.9.8",
+      "type": "checkpoint",
+      "base": "LTX-Video",
+      "save_path": "checkpoints/LTXV",
+      "description": "LTX-Video 13B distilled model v0.9.8 with improved prompt understanding and detail generation.",
+      "reference": "https://huggingface.co/Lightricks/LTX-Video",
+      "filename": "ltxv-13b-0.9.8-distilled.safetensors",
+      "url": "https://huggingface.co/Lightricks/LTX-Video/resolve/main/ltxv-13b-0.9.8-distilled.safetensors",
+      "size": "28.6GB"
+    },
+    {
+      "name": "LTX-Video 13B Distilled FP8 v0.9.8",
+      "type": "checkpoint",
+      "base": "LTX-Video",
+      "save_path": "checkpoints/LTXV",
+      "description": "Quantized LTX-Video 13B distilled model v0.9.8 with improved prompt understanding and detail generation, optimized for lower VRAM usage.",
+      "reference": "https://huggingface.co/Lightricks/LTX-Video",
+      "filename": "ltxv-13b-0.9.8-distilled-fp8.safetensors",
+      "url": "https://huggingface.co/Lightricks/LTX-Video/resolve/main/ltxv-13b-0.9.8-distilled-fp8.safetensors",
+      "size": "15.7GB"
+    },
+    {
       "name": "LTX-Video 13B Distilled LoRA v0.9.7",
       "type": "lora",
       "base": "LTX-Video",
@@ -5190,6 +5234,17 @@
       "filename": "ltxv-097-ic-lora-canny-control-comfyui.safetensors",
       "url": "https://huggingface.co/Lightricks/LTX-Video-ICLoRA-canny-13b-0.9.7/resolve/main/ltxv-097-ic-lora-canny-control-comfyui.safetensors",
       "size": "81.9MB"
+    },
+    {
+      "name": "LTX-Video ICLoRA Detailer 13B v0.9.8",
+      "type": "lora",
+      "base": "LTX-Video",
+      "save_path": "loras",
+      "description": "A video detailer model on top of LTXV_13B_098_DEV trained on custom data using In-Context LoRA (IC LoRA) method.",
+      "reference": "https://huggingface.co/Lightricks/LTX-Video-ICLoRA-detailer-13b-0.9.8",
+      "filename": "ltxv-098-ic-lora-detailer-comfyui.safetensors",
+      "url": "https://huggingface.co/Lightricks/LTX-Video-ICLoRA-detailer-13b-0.9.8/resolve/main/ltxv-098-ic-lora-detailer-comfyui.safetensors",
+      "size": "1.31GB"
     },
     {
       "name": "Latent Bridge Matching for Image Relighting",


### PR DESCRIPTION
- Add LTX-Video 2B Distilled v0.9.8 (6.34GB)
- Add LTX-Video 2B Distilled FP8 v0.9.8 (4.46GB)
- Add LTX-Video 13B Distilled v0.9.8 (28.6GB)
- Add LTX-Video 13B Distilled FP8 v0.9.8 (15.7GB)
- Add LTX-Video ICLoRA Detailer 13B v0.9.8 (1.31GB)

These v0.9.8 models feature improved prompt understanding and detail generation. Both 2B and 13B variants available in standard and FP8 quantized versions.