### PR TITLE
Added Save Image (Selective Metadata) node

### DIFF
--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -29865,6 +29865,17 @@
             ],
             "install_type": "unzip",
             "description": "This is a node to convert an image into a CMYK Halftone dot image."
+        },
+        {
+            "author": "brucew4yn3rp",
+            "title": "Save Image with Selective Metadata",
+            "id": "SaveImageSelectiveMetadata",
+            "reference": "https://github.com/brucew4yn3rp/ComfyUI_SelectiveMetadata",
+            "files": [
+                "https://github.com/brucew4yn3rp/ComfyUI_SelectiveMetadata"
+            ],
+            "install_type": "copy",
+            "description": "This custom node allows users to selectively choose what to add to the generated image's metadata."
         }
     ]
 }


### PR DESCRIPTION
In an effort to clean up image metadata, this custom node allows users to selectively choose what to add to the generated image's metadata. As a result, images will not be able to load ComfyUI workflows.

Currently, there are 5 inputs allowed, with each needing a key and corresponding metadata pair. If the key is empty, that key:metadata pair will be ignored.

The most prevalent use case for such selectivity is being able to save the prompt in a clear manner, as seen below.

To do so, the easiest method is to use a String Literal node when typing the prompt, which can output text to both CLIP Text Encode (Prompt) as well as the Save Image (Selective Metadata) node. An example of this can be seen in the below workflow.
image workflow

<img width="970" height="551" alt="image" src="https://github.com/user-attachments/assets/140c99cc-9f3f-406c-b1c7-daa69686ae19" />

<img width="2088" height="967" alt="workflow" src="https://github.com/user-attachments/assets/1ec4774f-5616-44aa-855b-7f39157dddf7" />