### PR TITLE
Update custom-node-list.json

### DIFF
--- a/node_db/dev/custom-node-list.json
+++ b/node_db/dev/custom-node-list.json
@@ -1,6 +1,17 @@
 {
     "custom_nodes": [
         {
+            "author": "vaishnav-vn",
+            "title": "va1",
+            "name": "Pad Image by Aspect",
+            "reference": "https://github.com/vaishnav-vn/va1",
+            "files": [
+                "https://github.com/vaishnav-vn/va1"
+            ],
+            "install_type": "git-clone",
+            "description": "repo has Custon node designed to expand, pad, and mask images to fixed or randomized aspect ratios with precise spatial and scale control — engineered for outpainting, compositional layout, and creative canvas expansion. "
+        },
+        {
             "author": "boricuapab",
             "title": "ComfyUI-Bori-KontextPresets [WIP]",
             "reference": "https://github.com/boricuapab/ComfyUI-Bori-KontextPresets",


### PR DESCRIPTION
Add Pad Image by Aspect node for outpainting and aspect ratio control.
This node is designed to expand, pad, and mask images to fixed or randomized aspect ratios with precise spatial and scale control — engineered for outpainting, compositional layout, and creative canvas expansion.