### PR TITLE
Migrate matrix-client to matrix-nio

### DIFF
--- a/glob/share_3rdparty.py
+++ b/glob/share_3rdparty.py
@@ -335,8 +335,8 @@ async def share_art(request):
         content_type = assetFileType
 
         try:
-            from matrix_client.api import MatrixHttpApi
-            from matrix_client.client import MatrixClient
+            from nio import AsyncClient, LoginResponse, RoomSendResponse, UploadResponse, RoomMessageText, RoomMessageMedia
+            import asyncio
 
             homeserver = 'matrix.org'
             if matrix_auth:
@@ -345,20 +345,35 @@ async def share_art(request):
             if not homeserver.startswith("https://"):
                 homeserver = "https://" + homeserver
 
-            client = MatrixClient(homeserver)
-            try:
-                token = client.login(username=matrix_auth['username'], password=matrix_auth['password'])
-                if not token:
-                    return web.json_response({"error": "Invalid Matrix credentials."}, content_type='application/json', status=400)
-            except:
+            client = AsyncClient(homeserver, matrix_auth['username'])
+
+            # Login
+            login_resp = await client.login(matrix_auth['password'])
+            if not isinstance(login_resp, LoginResponse) or not login_resp.access_token:
+                await client.close()
                 return web.json_response({"error": "Invalid Matrix credentials."}, content_type='application/json', status=400)
 
-            matrix = MatrixHttpApi(homeserver, token=token)
+            # Upload asset
             with open(asset_filepath, 'rb') as f:
-                mxc_url = matrix.media_upload(f.read(), content_type, filename=filename)['content_uri']
+                upload_resp, _maybe_keys = await client.upload(f, content_type=content_type, filename=filename)
+                asset_data = f.seek(0) or f.read()  # get size for info below
+            if not isinstance(upload_resp, UploadResponse) or not upload_resp.content_uri:
+                await client.close()
+                return web.json_response({"error": "Failed to upload asset to Matrix."}, content_type='application/json', status=500)
+            mxc_url = upload_resp.content_uri
 
-            workflow_json_mxc_url = matrix.media_upload(prompt['workflow'], 'application/json', filename='workflow.json')['content_uri']
+            # Upload workflow JSON
+            import io
+            workflow_json_bytes = json.dumps(prompt['workflow']).encode('utf-8')
+            workflow_io = io.BytesIO(workflow_json_bytes)
+            upload_workflow_resp, _maybe_keys = await client.upload(workflow_io, content_type='application/json', filename='workflow.json')
+            workflow_io.seek(0)
+            if not isinstance(upload_workflow_resp, UploadResponse) or not upload_workflow_resp.content_uri:
+                await client.close()
+                return web.json_response({"error": "Failed to upload workflow to Matrix."}, content_type='application/json', status=500)
+            workflow_json_mxc_url = upload_workflow_resp.content_uri
 
+            # Send text message
             text_content = ""
             if title:
                 text_content += f"{title}\n"
@@ -366,9 +381,44 @@ async def share_art(request):
                 text_content += f"{description}\n"
             if credits:
                 text_content += f"\ncredits: {credits}\n"
-            matrix.send_message(comfyui_share_room_id, text_content)
-            matrix.send_content(comfyui_share_room_id, mxc_url, filename, 'm.image')
-            matrix.send_content(comfyui_share_room_id, workflow_json_mxc_url, 'workflow.json', 'm.file')
+            await client.room_send(
+                room_id=comfyui_share_room_id,
+                message_type="m.room.message",
+                content={"msgtype": "m.text", "body": text_content}
+            )
+
+            # Send image
+            await client.room_send(
+                room_id=comfyui_share_room_id,
+                message_type="m.room.message",
+                content={
+                    "msgtype": "m.image",
+                    "body": filename,
+                    "url": mxc_url,
+                    "info": {
+                        "mimetype": content_type,
+                        "size": len(asset_data)
+                    }
+                }
+            )
+
+            # Send workflow JSON file
+            await client.room_send(
+                room_id=comfyui_share_room_id,
+                message_type="m.room.message",
+                content={
+                    "msgtype": "m.file",
+                    "body": "workflow.json",
+                    "url": workflow_json_mxc_url,
+                    "info": {
+                        "mimetype": "application/json",
+                        "size": len(workflow_json_bytes)
+                    }
+                }
+            )
+
+            await client.close()
+
         except:
             import traceback
             traceback.print_exc()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "comfyui-manager"
 description = "ComfyUI-Manager provides features to install and manage custom nodes for ComfyUI, as well as various functionalities to assist with ComfyUI."
 version = "3.34.5"
 license = { file = "LICENSE.txt" }
-dependencies = ["GitPython", "PyGithub", "matrix-client==0.4.0", "transformers", "huggingface-hub>0.20", "typer", "rich", "typing-extensions", "toml", "uv", "chardet"]
+dependencies = ["GitPython", "PyGithub", "matrix-nio", "transformers", "huggingface-hub>0.20", "typer", "rich", "typing-extensions", "toml", "uv", "chardet"]
 
 [project.urls]
 Repository = "https://github.com/ltdrdata/ComfyUI-Manager"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 GitPython
 PyGithub
-matrix-client==0.4.0
+matrix-nio
 transformers
 huggingface-hub>0.20
 typer


### PR DESCRIPTION
I've mentioned this before in the Discussions:
https://github.com/Comfy-Org/ComfyUI-Manager/discussions/1185

And by now it's more pressing:

* `matrix-client` is no longer working (at least in my tests)
* `matrix-client 0.4.0 depends on urllib3~=1.21` is causing more troubles (e.g. `gradio` depends on newer `urllib3`)

So I made this PR (with some help from Copilot and matrix-nio [examples](https://matrix-nio.readthedocs.io/en/latest/examples.html)).

My test screenshot:

<img width="1714" height="918" alt="20250724_073312" src="https://github.com/user-attachments/assets/f4c5f02e-626c-461c-a89b-1d28dc53e117" />

<img width="8728" height="5375" alt="20250724_073257" src="https://github.com/user-attachments/assets/809ab8f9-a372-4231-b6f0-3a4a48c04dda" />
