### PR TITLE
Update ComfyUI-FastVideo reference

### DIFF
--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -26864,14 +26864,14 @@
             "description": "Automatic background removal and transparency generation for ComfyUI"
         },
         {
-            "author": "kevin314",
+            "author": "hao-ai-lab",
             "title": "ComfyUI-FastVideo",
-            "reference": "https://github.com/kevin314/ComfyUI-FastVideo",
+            "reference": "https://github.com/hao-ai-lab/FastVideo",
             "files": [
-                "https://github.com/kevin314/ComfyUI-FastVideo"
+                "https://github.com/hao-ai-lab/FastVideo"
             ],
             "install_type": "git-clone",
-            "description": "A custom node suite for ComfyUI that provides accelerated video generation using [a/FastVideo](https://github.com/hao-ai-labs/FastVideo). See the [a/blog post](https://hao-ai-lab.github.io/blogs/fastvideo/) about FastVideo V1 to learn more."
+            "description": "A custom node suite for ComfyUI that provides accelerated multi-GPU video generation using [a/FastVideo](https://github.com/hao-ai-lab/FastVideo)."
         },
         {
             "author": "TensorKaze",


### PR DESCRIPTION
I was not aware that this node was added to this list already, thank you to whoever did that-- the FastVideo authors have asked to move the entire custom node into their main repo [https://github.com/hao-ai-lab/FastVideo](https://github.com/hao-ai-lab/FastVideo) for development there, so the old repo `https://github.com/kevin314/ComfyUI-FastVideo` is planned to be archived. 

Would this be possible? The custom node has been moved under `FastVideo/comfyui/` ([https://github.com/hao-ai-lab/FastVideo/tree/main/comfyui](https://github.com/hao-ai-lab/FastVideo/tree/main/comfyui)), and `FastVideo/__init__.py` ([https://github.com/hao-ai-lab/FastVideo/blob/main/__init__.py](https://github.com/hao-ai-lab/FastVideo/blob/main/__init__.py)) has been added with node class mappings.