### PR TITLE
Add Wan2.2 models from Comfy-Org

### DIFF
--- a/model-list.json
+++ b/model-list.json
@@ -5045,6 +5045,105 @@
       "size": "1.26GB"
     },
 
+    {
+      "name": "Comfy-Org/Wan2.2 i2v high noise 14B (fp16)",
+      "type": "diffusion_model",
+      "base": "Wan2.2",
+      "save_path": "diffusion_models/Wan2.2",
+      "description": "Wan2.2 diffusion model for i2v high noise 14B (fp16)",
+      "reference": "https://huggingface.co/Comfy-Org/Wan_2.2_ComfyUI_Repackaged",
+      "filename": "wan2.2_i2v_high_noise_14B_fp16.safetensors",
+      "url": "https://huggingface.co/Comfy-Org/Wan_2.2_ComfyUI_Repackaged/resolve/main/split_files/diffusion_models/wan2.2_i2v_high_noise_14B_fp16.safetensors",
+      "size": "28.6GB"
+    },
+    {
+      "name": "Comfy-Org/Wan2.2 i2v high noise 14B (fp8_scaled)",
+      "type": "diffusion_model",
+      "base": "Wan2.2",
+      "save_path": "diffusion_models/Wan2.2",
+      "description": "Wan2.2 diffusion model for i2v high noise 14B (fp8_scaled)",
+      "reference": "https://huggingface.co/Comfy-Org/Wan_2.2_ComfyUI_Repackaged",
+      "filename": "wan2.2_i2v_high_noise_14B_fp8_scaled.safetensors",
+      "url": "https://huggingface.co/Comfy-Org/Wan_2.2_ComfyUI_Repackaged/resolve/main/split_files/diffusion_models/wan2.2_i2v_high_noise_14B_fp8_scaled.safetensors",
+      "size": "14.3GB"
+    },
+    {
+      "name": "Comfy-Org/Wan2.2 i2v low noise 14B (fp16)",
+      "type": "diffusion_model",
+      "base": "Wan2.2",
+      "save_path": "diffusion_models/Wan2.2",
+      "description": "Wan2.2 diffusion model for i2v low noise 14B (fp16)",
+      "reference": "https://huggingface.co/Comfy-Org/Wan_2.2_ComfyUI_Repackaged",
+      "filename": "wan2.2_i2v_low_noise_14B_fp16.safetensors",
+      "url": "https://huggingface.co/Comfy-Org/Wan_2.2_ComfyUI_Repackaged/resolve/main/split_files/diffusion_models/wan2.2_i2v_low_noise_14B_fp16.safetensors",
+      "size": "28.6GB"
+    },
+    {
+      "name": "Comfy-Org/Wan2.2 i2v low noise 14B (fp8_scaled)",
+      "type": "diffusion_model",
+      "base": "Wan2.2",
+      "save_path": "diffusion_models/Wan2.2",
+      "description": "Wan2.2 diffusion model for i2v low noise 14B (fp8_scaled)",
+      "reference": "https://huggingface.co/Comfy-Org/Wan_2.2_ComfyUI_Repackaged",
+      "filename": "wan2.2_i2v_low_noise_14B_fp8_scaled.safetensors",
+      "url": "https://huggingface.co/Comfy-Org/Wan_2.2_ComfyUI_Repackaged/resolve/main/split_files/diffusion_models/wan2.2_i2v_low_noise_14B_fp8_scaled.safetensors",
+      "size": "14.3GB"
+    },
+    {
+      "name": "Comfy-Org/Wan2.2 t2v high noise 14B (fp16)",
+      "type": "diffusion_model",
+      "base": "Wan2.2",
+      "save_path": "diffusion_models/Wan2.2",
+      "description": "Wan2.2 diffusion model for t2v high noise 14B (fp16)",
+      "reference": "https://huggingface.co/Comfy-Org/Wan_2.2_ComfyUI_Repackaged",
+      "filename": "wan2.2_t2v_high_noise_14B_fp16.safetensors",
+      "url": "https://huggingface.co/Comfy-Org/Wan_2.2_ComfyUI_Repackaged/resolve/main/split_files/diffusion_models/wan2.2_t2v_high_noise_14B_fp16.safetensors",
+      "size": "28.6GB"
+    },
+    {
+      "name": "Comfy-Org/Wan2.2 t2v high noise 14B (fp8_scaled)",
+      "type": "diffusion_model",
+      "base": "Wan2.2",
+      "save_path": "diffusion_models/Wan2.2",
+      "description": "Wan2.2 diffusion model for t2v high noise 14B (fp8_scaled)",
+      "reference": "https://huggingface.co/Comfy-Org/Wan_2.2_ComfyUI_Repackaged",
+      "filename": "wan2.2_t2v_high_noise_14B_fp8_scaled.safetensors",
+      "url": "https://huggingface.co/Comfy-Org/Wan_2.2_ComfyUI_Repackaged/resolve/main/split_files/diffusion_models/wan2.2_t2v_high_noise_14B_fp8_scaled.safetensors",
+      "size": "14.3GB"
+    },
+    {
+      "name": "Comfy-Org/Wan2.2 t2v low noise 14B (fp16)",
+      "type": "diffusion_model",
+      "base": "Wan2.2",
+      "save_path": "diffusion_models/Wan2.2",
+      "description": "Wan2.2 diffusion model for t2v low noise 14B (fp16)",
+      "reference": "https://huggingface.co/Comfy-Org/Wan_2.2_ComfyUI_Repackaged",
+      "filename": "wan2.2_t2v_low_noise_14B_fp16.safetensors",
+      "url": "https://huggingface.co/Comfy-Org/Wan_2.2_ComfyUI_Repackaged/resolve/main/split_files/diffusion_models/wan2.2_t2v_low_noise_14B_fp16.safetensors",
+      "size": "28.6GB"
+    },
+    {
+      "name": "Comfy-Org/Wan2.2 t2v low noise 14B (fp8_scaled)",
+      "type": "diffusion_model",
+      "base": "Wan2.2",
+      "save_path": "diffusion_models/Wan2.2",
+      "description": "Wan2.2 diffusion model for t2v low noise 14B (fp8_scaled)",
+      "reference": "https://huggingface.co/Comfy-Org/Wan_2.2_ComfyUI_Repackaged",
+      "filename": "wan2.2_t2v_low_noise_14B_fp8_scaled.safetensors",
+      "url": "https://huggingface.co/Comfy-Org/Wan_2.2_ComfyUI_Repackaged/resolve/main/split_files/diffusion_models/wan2.2_t2v_low_noise_14B_fp8_scaled.safetensors",
+      "size": "14.3GB"
+    },
+    {
+      "name": "Comfy-Org/Wan2.2 ti2v 5B (fp16)",
+      "type": "diffusion_model",
+      "base": "Wan2.2",
+      "save_path": "diffusion_models/Wan2.2",
+      "description": "Wan2.2 diffusion model for ti2v 5B (fp16)",
+      "reference": "https://huggingface.co/Comfy-Org/Wan_2.2_ComfyUI_Repackaged",
+      "filename": "wan2.2_ti2v_5B_fp16.safetensors",
+      "url": "https://huggingface.co/Comfy-Org/Wan_2.2_ComfyUI_Repackaged/resolve/main/split_files/diffusion_models/wan2.2_ti2v_5B_fp16.safetensors",
+      "size": "10.0GB"
+    },
 
     {
       "name": "Comfy-Org/umt5_xxl_fp16.safetensors",


### PR DESCRIPTION
This pull request updates model-list.json with the Wan2.2 models published by Comfy-Org, following the existing pattern used for the Wan2.1 models.