### PR TITLE
Fix JSON serialization error in bulk import fail info API

### DIFF
--- a/comfyui_manager/glob/manager_server.py
+++ b/comfyui_manager/glob/manager_server.py
@@ -62,7 +62,6 @@ from ..data_models import (
     BatchExecutionRecord,
     ComfyUISystemState,
     ImportFailInfoBulkRequest,
-    ImportFailInfoBulkResponse,
     BatchOperation,
     InstalledNodeInfo,
     ComfyUIVersionInfo,

--- a/comfyui_manager/glob/manager_server.py
+++ b/comfyui_manager/glob/manager_server.py
@@ -1683,7 +1683,11 @@ async def import_fail_info_bulk(request):
                 if module_name is not None:
                     info = cm_global.error_dict.get(module_name)
                     if info is not None:
-                        results[cnr_id] = info
+                        # Convert error_dict format to API spec format
+                        results[cnr_id] = {
+                            'error': info.get('msg', ''),
+                            'traceback': info.get('traceback', '')
+                        }
                     else:
                         results[cnr_id] = None
                 else:
@@ -1695,15 +1699,18 @@ async def import_fail_info_bulk(request):
                 if module_name is not None:
                     info = cm_global.error_dict.get(module_name)
                     if info is not None:
-                        results[url] = info
+                        # Convert error_dict format to API spec format
+                        results[url] = {
+                            'error': info.get('msg', ''),
+                            'traceback': info.get('traceback', '')
+                        }
                     else:
                         results[url] = None
                 else:
                     results[url] = None
 
-        # Create response using Pydantic model
-        response_data = ImportFailInfoBulkResponse(root=results)
-        return web.json_response(response_data.root)
+        # Return results directly as JSON
+        return web.json_response(results, content_type="application/json")
     except ValidationError as e:
         logging.error(f"[ComfyUI-Manager] Invalid request data: {e}")
         return web.Response(status=400, text=f"Invalid request data: {e}")


### PR DESCRIPTION
## Problem
The `/v2/customnode/import_fail_info_bulk` endpoint was throwing a JSON serialization error:
```
[ComfyUI-Manager] Error processing bulk import fail info: Object of type ImportFailInfoItem is not JSON serializable
```

## Root Cause
The error occurred due to a mismatch between the internal data structure and the API specification:

1. **Internal data structure** (`cm_global.error_dict`):
   ```python
   {
       'name': 'node-name',
       'path': '/path/to/node',
       'msg': 'error message'
   }
   ```

2. **API spec expects** (`ImportFailInfoItem`):
   ```python
   {
       'error': 'error string',
       'traceback': 'traceback string'
   }
   ```

3. The code was trying to serialize the Pydantic model `ImportFailInfoBulkResponse` which contained incompatible data structures, causing the serialization failure.

## Solution
- Transform the data from `cm_global.error_dict` format to match the API specification
- Map `msg` field to `error` field
- Add empty `traceback` field when not present
- Remove Pydantic model serialization and return plain dict directly as JSON

## Changes Made
1. Added data transformation in the bulk endpoint to convert error dict format:
   ```python
   results[cnr_id] = {
       'error': info.get('msg', ''),
       'traceback': info.get('traceback', '')
   }
   ```

2. Removed problematic Pydantic model serialization:
   - Before: `return web.json_response(response_data.root)`
   - After: `return web.json_response(results, content_type="application/json")`

## Testing
Tested with the following curl command and confirmed it returns proper JSON response without errors:
```bash
curl 'http://localhost:8188/api/v2/customnode/import_fail_info_bulk' \
  -H 'Content-Type: application/json' \
  --data-raw '{"cnr_ids":["comfyui-manager","teacache","comfyui-gguf"]}'
```

## Impact
- Fixes the 500 Internal Server Error when calling the bulk import fail info endpoint
- Ensures consistent API response format across single and bulk endpoints
- Maintains backward compatibility with existing API contracts