### PR TITLE
Add ComfyUI-LoRAWeightAxisXY

### DIFF
--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -32561,14 +32561,17 @@
             ],
             "install_type": "unzip",
             "description": "This is a node to convert an image into a CMYK Halftone dot image."
-        }
+        },
 		{
-		  "name": "ComfyUI-LoRAWeightAxisXY",
-		  "author": "Frief84",
-		  "url": "https://github.com/Frief84/ComfyUI-LoRAWeightAxisXY",
-		  "description": "Adds `XY Input: LoRA Weight (simple)` for Efficiency Nodes. Outputs XY subtype 'LoRA' (name, weight, weight) with a linear sweep; works with `XY Input: Checkpoint`.",
-		  "license": "MIT",
-		  "tags": ["xy-plot", "lora", "efficiency-nodes", "utility"]
+            "author": "Frief84",
+            "title": "ComfyUI-LoRAWeightAxisXY",
+            "reference": "https://github.com/Frief84/ComfyUI-LoRAWeightAxisXY",
+            "files": [
+                "https://github.com/Frief84/ComfyUI-LoRAWeightAxisXY"
+            ],
+            "description": "Adds `XY Input: LoRA Weight (simple)` for Efficiency Nodes. Outputs XY subtype 'LoRA' (name, weight, weight) with a linear sweep; works with `XY Input: Checkpoint`.",
+            "install_type": "git-clone",			
+            "tags": ["xy-plot", "lora", "efficiency-nodes", "utility"]
 		}
     ]
 }

--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -32562,5 +32562,13 @@
             "install_type": "unzip",
             "description": "This is a node to convert an image into a CMYK Halftone dot image."
         }
+		{
+		  "name": "ComfyUI-LoRAWeightAxisXY",
+		  "author": "Frief84",
+		  "url": "https://github.com/Frief84/ComfyUI-LoRAWeightAxisXY",
+		  "description": "Adds `XY Input: LoRA Weight (simple)` for Efficiency Nodes. Outputs XY subtype 'LoRA' (name, weight, weight) with a linear sweep; works with `XY Input: Checkpoint`.",
+		  "license": "MIT",
+		  "tags": ["xy-plot", "lora", "efficiency-nodes", "utility"]
+		}
     ]
 }


### PR DESCRIPTION
Adds “XY Input: LoRA Weight (simple)” for Efficiency Nodes — a tiny XY input that linearly sweeps LoRA strength (min→max, steps) and outputs XY subtype `LoRA`, so it pairs with “XY Input: Checkpoint” to plot checkpoint × weight grids.  
Repo: https://github.com/Frief84/ComfyUI-LoRAWeightAxisXY · License: MIT