### PR TITLE
Add custom node: comfyui_nakagawa for websocket video data handling

### DIFF
--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -33246,6 +33246,16 @@
             ],
             "install_type": "unzip",
             "description": "This is a node to convert an image into a CMYK Halftone dot image."
+        },
+        {
+            "author": "nakagawadev",
+            "title": "comfyui_nakagawa",
+            "reference": "https://github.com/nakagawadev/comfyui_nakagawa",
+            "files": [
+                "https://github.com/nakagawadev/comfyui_nakagawa"
+            ],
+            "install_type": "git-clone",
+            "description": "A collection of custom nodes for ComfyUI that send video data through websockets instead of saving to disk."
         }
     ]
 }


### PR DESCRIPTION
Video websocket nodes for ComfyUI that send video data through websockets instead of saving to disk. Includes Save Video Websocket and Save WEBM Websocket nodes as alternatives to native ComfyUI video nodes