### PR TITLE
docs: fix typos and wording in README and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 
 To install ComfyUI-Manager in addition to an existing installation of ComfyUI, you can follow the following steps:
 
-1. goto `ComfyUI/custom_nodes` dir in terminal(cmd)
+1. Go to `ComfyUI/custom_nodes` dir in terminal (cmd)
 2. `git clone https://github.com/ltdrdata/ComfyUI-Manager comfyui-manager`
 3. Restart ComfyUI
 
@@ -28,8 +28,8 @@ To install ComfyUI-Manager in addition to an existing installation of ComfyUI, y
 - standalone version  
 - select option: use windows default console window
 2. Download [scripts/install-manager-for-portable-version.bat](https://github.com/ltdrdata/ComfyUI-Manager/raw/main/scripts/install-manager-for-portable-version.bat) into installed `"ComfyUI_windows_portable"` directory
-- Don't click. Right click the link and use save as...
-3. double click `install-manager-for-portable-version.bat` batch file
+- Don't click. Right-click the link and choose 'Save As...'
+3. Double-click `install-manager-for-portable-version.bat` batch file
 
 ![portable-install](https://raw.githubusercontent.com/ltdrdata/ComfyUI-extension-tutorials/Main/ComfyUI-Manager/images/portable-install.jpg)
 
@@ -47,7 +47,7 @@ pip install comfy-cli
 comfy install
 ```
 
-Linux/OSX:
+Linux/macOS:
 ```commandline
 python -m venv venv
 . venv/bin/activate
@@ -57,13 +57,13 @@ comfy install
 * See also: https://github.com/Comfy-Org/comfy-cli
 
 
-### Installation[method4] (Installation for linux+venv: ComfyUI + ComfyUI-Manager)
+### Installation[method4] (Installation for Linux+venv: ComfyUI + ComfyUI-Manager)
 
 To install ComfyUI with ComfyUI-Manager on Linux using a venv environment, you can follow these steps:
 * **prerequisite: python-is-python3, python3-venv, git**
 
 1. Download [scripts/install-comfyui-venv-linux.sh](https://github.com/ltdrdata/ComfyUI-Manager/raw/main/scripts/install-comfyui-venv-linux.sh) into empty install directory
-- Don't click. Right click the link and use save as...
+- Don't click. Right-click the link and choose 'Save As...'
 - ComfyUI will be installed in the subdirectory of the specified directory, and the directory will contain the generated executable script.
 2. `chmod +x install-comfyui-venv-linux.sh`
 3. `./install-comfyui-venv-linux.sh`
@@ -176,7 +176,7 @@ The following settings are applied based on the section marked as `is_default`.
 ![model-install-dialog](https://raw.githubusercontent.com/ltdrdata/ComfyUI-extension-tutorials/Main/ComfyUI-Manager/images/snapshot.jpg)
 
 
-## cm-cli: command line tools for power user
+## cm-cli: command line tools for power users
 * A tool is provided that allows you to use the features of ComfyUI-Manager without running ComfyUI.
 * For more details, please refer to the [cm-cli documentation](docs/en/cm-cli.md).
 
@@ -222,7 +222,7 @@ The following settings are applied based on the section marked as `is_default`.
   * `<current timestamp>` Ensure that the timestamp is always unique.
     * "components" should have the same structure as the content of the file stored in `<USER_DIRECTORY>/default/ComfyUI-Manager/components`.
       * `<component name>`: The name should be in the format `<prefix>::<node name>`.
-        * `<compnent nodeata>`: In the nodedata of the group node.
+        * `<component node data>`: In the node data of the group node.
           * `<version>`: Only two formats are allowed: `major.minor.patch` or `major.minor`. (e.g. `1.0`, `2.2.1`)
           * `<datetime>`: Saved time
           * `<packname>`: If the packname is not empty, the category becomes packname/workflow, and it is saved in the <packname>.pack file in `<USER_DIRECTORY>/default/ComfyUI-Manager/components`.
@@ -240,7 +240,7 @@ The following settings are applied based on the section marked as `is_default`.
 * Dragging and dropping or pasting a single component will add a node. However, when adding multiple components, nodes will not be added.
 
 
-## Support of missing nodes installation
+## Support for installing missing nodes
 
 ![missing-menu](https://raw.githubusercontent.com/ltdrdata/ComfyUI-extension-tutorials/Main/ComfyUI-Manager/images/missing-menu.jpg)
 
@@ -279,10 +279,10 @@ The following settings are applied based on the section marked as `is_default`.
 * Logging to file feature
   * This feature is enabled by default and can be disabled by setting `file_logging = False` in the `config.ini`.
 
-* Fix node(recreate): When right-clicking on a node and selecting `Fix node (recreate)`, you can recreate the node. The widget's values are reset, while the connections maintain those with the same names.
+* Fix node (recreate): When right-clicking on a node and selecting `Fix node (recreate)`, you can recreate the node. The widget's values are reset, while the connections maintain those with the same names.
   * It is used to correct errors in nodes of old workflows created before, which are incompatible with the version changes of custom nodes.
 
-* Double-Click Node Title: You can set the double click behavior of nodes in the ComfyUI-Manager menu.
+* Double-Click Node Title: You can set the double-click behavior of nodes in the ComfyUI-Manager menu.
   * `Copy All Connections`, `Copy Input Connections`: Double-clicking a node copies the connections of the nearest node.
     * This action targets the nearest node within a straight-line distance of 1000 pixels from the center of the node.
     * In the case of `Copy All Connections`, it duplicates existing outputs, but since it does not allow duplicate connections, the existing output connections of the original node are disconnected.
@@ -348,7 +348,7 @@ When you run the `scan.sh` script:
 
 * It updates the `github-stats.json`.
   * This uses the GitHub API, so set your token with `export GITHUB_TOKEN=your_token_here` to avoid quickly reaching the rate limit and malfunctioning.
-  * To skip this step, add the `--skip-update-stat` option.
+  * To skip this step, add the `--skip-stat-update` option.
 
 * The `--skip-all` option applies both `--skip-update` and `--skip-stat-update`.
 
@@ -356,9 +356,9 @@ When you run the `scan.sh` script:
 ## Troubleshooting
 * If your `git.exe` is installed in a specific location other than system git, please install ComfyUI-Manager and run ComfyUI. Then, specify the path including the file name in `git_exe = ` in the `<USER_DIRECTORY>/default/ComfyUI-Manager/config.ini` file that is generated.
 * If updating ComfyUI-Manager itself fails, please go to the **ComfyUI-Manager** directory and execute the command `git update-ref refs/remotes/origin/main a361cc1 && git fetch --all && git pull`.
-* If you encounter the error message `Overlapped Object has pending operation at deallocation on Comfyui Manager load` under Windows
+* If you encounter the error message `Overlapped Object has pending operation at deallocation on ComfyUI Manager load` under Windows
   * Edit `config.ini` file: add `windows_selector_event_loop_policy = True`
-* if `SSL: CERTIFICATE_VERIFY_FAILED` error is occured.
+* If the `SSL: CERTIFICATE_VERIFY_FAILED` error occurs.
   * Edit `config.ini` file: add `bypass_ssl = True`
 
 

--- a/docs/en/cm-cli.md
+++ b/docs/en/cm-cli.md
@@ -139,7 +139,7 @@ You can set whether to use ComfyUI-Manager solely via CLI.
 `restore-dependencies`
 
 * This command can be used if custom nodes are installed under the `ComfyUI/custom_nodes` path but their dependencies are not installed.
-* It is useful when starting a new cloud instance, like colab, where dependencies need to be reinstalled and installation scripts re-executed.
+* It is useful when starting a new cloud instance, like Colab, where dependencies need to be reinstalled and installation scripts re-executed.
 * It can also be utilized if ComfyUI is reinstalled and only the custom_nodes path has been backed up and restored.
 
 ### 7. Clear

--- a/docs/ko/cm-cli.md
+++ b/docs/ko/cm-cli.md
@@ -23,13 +23,13 @@ OPTIONS:
 ## How To Use?
 * `python cm-cli.py` 를 통해서 실행 시킬 수 있습니다.
 * 예를 들어 custom node를 모두 업데이트 하고 싶다면
-    * ComfyUI-Manager경로 에서 `python cm-cli.py update all` 를 command를 실행할 수 있습니다.
+    * ComfyUI-Manager 경로에서 `python cm-cli.py update all` 명령을 실행할 수 있습니다.
     * ComfyUI 경로에서 실행한다면, `python custom_nodes/ComfyUI-Manager/cm-cli.py update all` 와 같이 cm-cli.py 의 경로를 지정할 수도 있습니다.
 
 ## Prerequisite
 * ComfyUI 를 실행하는 python과 동일한 python 환경에서 실행해야 합니다.
     * venv를 사용할 경우 해당 venv를 activate 한 상태에서 실행해야 합니다.
-    * portable 버전을 사용할 경우 run_nvidia_gpu.bat 파일이 있는 경로인 경우, 다음과 같은 방식으로 코맨드를 실행해야 합니다.
+* portable 버전을 사용할 경우 run_nvidia_gpu.bat 파일이 있는 경로인 경우, 다음과 같은 방식으로 명령을 실행해야 합니다.
         `.\python_embeded\python.exe ComfyUI\custom_nodes\ComfyUI-Manager\cm-cli.py update all`
 * ComfyUI 의 경로는 COMFYUI_PATH 환경 변수로 설정할 수 있습니다. 만약 생략할 경우 다음과 같은 경고 메시지가 나타나며, ComfyUI-Manager가 설치된 경로를 기준으로 상대 경로로 설정됩니다.
         ```
@@ -40,8 +40,8 @@ OPTIONS:
 
 ### 1. --channel, --mode
 * 정보 보기 기능과 커스텀 노드 관리 기능의 경우는 --channel과 --mode를 통해 정보 DB를 설정할 수 있습니다.
-* 예들 들어 `python cm-cli.py update all --channel recent --mode remote`와 같은 command를 실행할 경우, 현재 ComfyUI-Manager repo에 내장된 로컬의 정보가 아닌 remote의 최신 정보를 기준으로 동작하며, recent channel에 있는 목록을 대상으로만 동작합니다.
-* --channel, --mode 는 `simple-show, show, install, uninstall, update, disable, enable, fix` command에서만 사용 가능합니다.
+* 예를 들어 `python cm-cli.py update all --channel recent --mode remote`와 같은 명령을 실행할 경우, 현재 ComfyUI-Manager repo에 내장된 로컬의 정보가 아닌 remote의 최신 정보를 기준으로 동작하며, recent channel에 있는 목록을 대상으로만 동작합니다.
+* --channel, --mode 는 `simple-show, show, install, uninstall, update, disable, enable, fix` 명령에서만 사용 가능합니다.
 
 ### 2. 관리 정보 보기
 
@@ -51,7 +51,7 @@ OPTIONS:
 * `[show|simple-show]` - `show`는 상세하게 정보를 보여주며, `simple-show`는 간단하게 정보를 보여줍니다.
 
 
-`python cm-cli.py show installed` 와 같은 코맨드를 실행하면 설치된 커스텀 노드의 정보를 상세하게 보여줍니다.
+`python cm-cli.py show installed` 와 같은 명령을 실행하면 설치된 커스텀 노드의 정보를 상세하게 보여줍니다.
 ```
 -= ComfyUI-Manager CLI (V2.24) =-
 
@@ -67,7 +67,7 @@ FETCH DATA from: https://raw.githubusercontent.com/ltdrdata/ComfyUI-Manager/main
 [    DISABLED   ]  ComfyUI-Loopchain                                 (author: Fannovel16)
 ```
 
-`python cm-cli.py simple-show installed` 와 같은 코맨드를 이용해서 설치된 커스텀 노드의 정보를 간단하게 보여줍니다.
+`python cm-cli.py simple-show installed` 와 같은 명령을 이용해서 설치된 커스텀 노드의 정보를 간단하게 보여줍니다.
 
 ```
 -= ComfyUI-Manager CLI (V2.24) =-
@@ -89,7 +89,7 @@ ComfyUI-Loopchain
     * `installed`: enable, disable 여부와 상관없이 설치된 모든 노드를 보여줍니다
     * `not-installed`: 설치되지 않은 커스텀 노드의 목록을 보여줍니다.
     * `all`: 모든 커스텀 노드의 목록을 보여줍니다.
-    * `snapshot`: 현재 설치된 커스텀 노드의 snapshot 정보를 보여줍니다. `show`롤 통해서 볼 경우는 json 출력 형태로  보여주며, `simple-show`를 통해서 볼 경우는 간단하게, 커밋 해시와 함께 보여줍니다.
+    * `snapshot`: 현재 설치된 커스텀 노드의 snapshot 정보를 보여줍니다. `show`를 통해서 볼 경우는 json 출력 형태로 보여주며, `simple-show`를 통해서 볼 경우는 간단하게, 커밋 해시와 함께 보여줍니다.
     * `snapshot-list`: ComfyUI-Manager/snapshots 에 저장된 snapshot 파일의 목록을 보여줍니다.
 
 ### 3. 커스텀 노드 관리 하기
@@ -98,7 +98,7 @@ ComfyUI-Loopchain
 
 * `python cm-cli.py install ComfyUI-Impact-Pack ComfyUI-Inspire-Pack ComfyUI_experiments` 와 같이 커스텀 노드의 이름을 나열해서 관리 기능을 적용할 수 있습니다.
 * 커스텀 노드의 이름은 `show`를 했을 때 보여주는 이름이며, git repository의 이름입니다. 
-(추후 nickname 을 사용가능하돌고 업데이트 할 예정입니다.)
+(추후 nickname을 사용 가능하도록 업데이트할 예정입니다.)
 
 `[update|disable|enable|fix] all ?[--channel <channel name>] ?[--mode [remote|local|cache]]`
 
@@ -124,7 +124,7 @@ ComfyUI-Loopchain
   * `--pip-non-local-url`: web URL에 등록된 pip 패키지들에 대해서 복구를 수행
   * `--pip-local-url`: local 경로를 지정하고 있는 pip 패키지들에 대해서 복구를 수행 
   * `--user-directory`: 사용자 디렉토리 설정
-  * `--restore-to`: 복구될 커스텀 노드가 설치될 경로. (이 옵션을 적용할 경우 오직 대상 경로에 설치된 custom nodes 만 설치된 것으로 인식함.)
+  * `--restore-to`: 복구될 커스텀 노드가 설치될 경로. (이 옵션을 적용할 경우 오직 대상 경로에 설치된 custom nodes만 설치된 것으로 인식함.)
 
 ### 5. CLI only mode
 
@@ -133,7 +133,7 @@ ComfyUI-Manager를 CLI로만 사용할 것인지를 설정할 수 있습니다.
 `cli-only-mode [enable|disable]`
 
 * security 혹은 policy 의 이유로 GUI 를 통한 ComfyUI-Manager 사용을 제한하고 싶은 경우 이 모드를 사용할 수 있습니다.
-    * CLI only mode를 적용할 경우 ComfyUI-Manager 가 매우 제한된 상태로 로드되어, 내부적으로 제공하는 web API가 비활성화 되며, 메인 메뉴에서도 Manager 버튼이 표시되지 않습니다.
+    * CLI only mode를 적용할 경우 ComfyUI-Manager 가 매우 제한된 상태로 로드되어, 내부적으로 제공하는 web API가 비활성화되며, 메인 메뉴에서도 Manager 버튼이 표시되지 않습니다.
 
 
 ### 6. 의존성 설치
@@ -141,10 +141,10 @@ ComfyUI-Manager를 CLI로만 사용할 것인지를 설정할 수 있습니다.
 `restore-dependencies`
 
 * `ComfyUI/custom_nodes` 하위 경로에 커스텀 노드들이 설치되어 있긴 하지만, 의존성이 설치되지 않은 경우 사용할 수 있습니다.
-* colab 과 같이 cloud instance를 새로 시작하는 경우 의존성 재설치 및 설치 스크립트가 재실행 되어야 하는 경우 사용합니다.
-* ComfyUI을 재설치할 경우, custom_nodes 경로만 백업했다가 재설치 할 경우 활용 가능합니다.
+* Colab과 같이 cloud instance를 새로 시작하는 경우 의존성 재설치 및 설치 스크립트가 재실행되어야 하는 경우 사용합니다.
+* ComfyUI를 재설치할 경우, custom_nodes 경로만 백업했다가 재설치할 경우 활용 가능합니다.
 
 
 ### 7. clear
 
-GUI에서 install, update를 하거나 snapshot 을 restore하는 경우 예약을 통해서 다음번 ComfyUI를 실행할 경우 실행되는 구조입니다. `clear` 는 이런 예약 상태를 clear해서, 아무런 사전 실행이 적용되지 않도록 합니다.
+GUI에서 install, update를 하거나 snapshot을 restore하는 경우 예약을 통해서 다음번 ComfyUI를 실행할 경우 실행되는 구조입니다. `clear` 는 이런 예약 상태를 clear해서, 아무런 사전 실행이 적용되지 않도록 합니다.

--- a/js/README.md
+++ b/js/README.md
@@ -13,7 +13,7 @@ This directory contains the JavaScript frontend implementation for ComfyUI-Manag
 ## Sharing Components
 
 - **comfyui-share-common.js**: Base functionality for workflow sharing features.
-- **comfyui-share-copus.js**: Integration with the ComfyUI Opus sharing platform.
+- **comfyui-share-copus.js**: Integration with the ComfyUI Copus sharing platform.
 - **comfyui-share-openart.js**: Integration with the OpenArt sharing platform.
 - **comfyui-share-youml.js**: Integration with the YouML sharing platform.
 


### PR DESCRIPTION
**Summary**
- Fix typos, grammar, capitalization, and wording across README and docs.

**Changes**
- README.md
  - "goto" → "Go to"; "Linux/OSX" → "Linux/macOS"; normalize “Double-click” and “Right-click … ‘Save As…’”
  - Heading: “Support for installing missing nodes”
  - Placeholders: use “<component node data>” and phrase “node data”
  - Error/case: “ComfyUI Manager”, “occurs”
  - Align option name with script: `--skip-update-stat` → `--skip-stat-update`
- js/README.md: use “Copus” (copus.io) instead of “Opus”
- docs/en/cm-cli.md: capitalize “Colab”
- docs/ko/cm-cli.md: spacing, typos, and wording fixes (예를, 명령, show를, 등) and minor grammar

**Rationale**
- Improves readability and prevents confusion (notably the `--skip-stat-update` flag).
- Documentation-only changes.

**Scope**
- Docs only. No code changes or behavioral impact.

**Verification**
- Searched for variants with ripgrep.
- Confirmed `scanner.py` uses `--skip-stat-update`.
