### PR TITLE
Add vae-decode-hdr node with HDR support

### DIFF
--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -33634,6 +33634,16 @@
             ],
             "install_type": "unzip",
             "description": "This is a node to convert an image into a CMYK Halftone dot image."
-        }
+        },
+		{
+		    "author": "sumitchatterjee13",
+		    "title": "vae-decode-hdr",
+		    "reference": "https://github.com/sumitchatterjee13/vae-decode-hdr",
+		    "files": [
+		        "https://github.com/sumitchatterjee13/vae-decode-hdr"
+		    ],
+		    "install_type": "git-clone",
+		    "description": "A custom ComfyUI node that preserves High Dynamic Range (HDR) data during VAE decoding, bypassing the default 0-1 range clamping. It also includes a companion 'Linear EXR Export' node for creating professional-grade linear EXR files."
+		}
     ]
 }


### PR DESCRIPTION
Added a new custom The vae-decode-hdr repository is for a custom ComfyUI node designed to preserve High Dynamic Range (HDR) data during VAE decoding. The developer, Sumit Chatterjee, created this node to address the limitation of ComfyUI's default VAE Decode node, which compresses outputs to a 0-1 pixel range, resulting in a loss of dynamic range.

The node uses a "scientific approach" to analyze the VAE's conv_out layer and intelligently expand highlight regions, bypassing the clipping that typically occurs. The repository also includes a companion tool called the "Linear EXR Export" node, which is essential for creating professional HDR output files that are ready for use in compositing software. The project is licensed under the MIT License and is open to contributions.ComfyUI node for HDR VAE decoding.