### PR TITLE
Fix CRT-Nodes GitHub reference (plugcrypt → PGCRT)

### DIFF
--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -18366,10 +18366,10 @@
             "author": "CRT",
             "title": "CRT-Nodes",
             "id": "crt-nodes",
-            "reference": "https://github.com/plugcrypt/CRT-Nodes",
+            "reference": "https://github.com/PGCRT/CRT-Nodes",
             "reference2": "https://github.com/PGCRT/CRT-Nodes",
             "files": [
-                "https://github.com/plugcrypt/CRT-Nodes"
+                "https://github.com/PGCRT/CRT-Nodes"
             ],
             "install_type": "git-clone",
             "description": "CRT-Nodes is a collection of custom nodes for ComfyUI"


### PR DESCRIPTION
The CRT-Nodes repository was transferred to a new GitHub account. Update the two URLs still pointing to the old `plugcrypt` username to `PGCRT`.