### PR TITLE
Add CRT nodes to default channel + fix CRT-Nodes reference

### DIFF
--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -18364,12 +18364,44 @@
         },
         {
             "author": "CRT",
+            "title": "CRT-HeartMuLa",
+            "id": "crt-heartmula",
+            "reference": "https://github.com/PGCRT/CRT-HeartMuLa",
+            "files": [
+                "https://github.com/PGCRT/CRT-HeartMuLa"
+            ],
+            "install_type": "git-clone",
+            "description": "A ComfyUI custom node for AI music generation using HeartMuLa models."
+        },
+        {
+            "author": "CRT",
+            "title": "ComfyUI-OmniVoice_CRT",
+            "id": "comfyui-omnivoice-crt",
+            "reference": "https://github.com/PGCRT/ComfyUI-OmniVoice_CRT",
+            "files": [
+                "https://github.com/PGCRT/ComfyUI-OmniVoice_CRT"
+            ],
+            "install_type": "git-clone",
+            "description": "ComfyUI wrapper nodes for OmniVoice multilingual zero-shot TTS."
+        },
+        {
+            "author": "CRT",
+            "title": "ComfyUI-QWEN3_TTS",
+            "id": "comfyui-qwen3-tts",
+            "reference": "https://github.com/PGCRT/ComfyUI-QWEN3_TTS",
+            "files": [
+                "https://github.com/PGCRT/ComfyUI-QWEN3_TTS"
+            ],
+            "install_type": "git-clone",
+            "description": "Fast and efficient Text-to-Speech nodes for ComfyUI based on Qwen3-TTS."
+        },
+        {
+            "author": "CRT",
             "title": "CRT-Nodes",
             "id": "crt-nodes",
-            "reference": "https://github.com/plugcrypt/CRT-Nodes",
-            "reference2": "https://github.com/PGCRT/CRT-Nodes",
+            "reference": "https://github.com/PGCRT/CRT-Nodes",
             "files": [
-                "https://github.com/plugcrypt/CRT-Nodes"
+                "https://github.com/PGCRT/CRT-Nodes"
             ],
             "install_type": "git-clone",
             "description": "CRT-Nodes is a collection of custom nodes for ComfyUI"


### PR DESCRIPTION
## Summary

- Add **CRT-HeartMuLa**, **ComfyUI-OmniVoice_CRT**, and **ComfyUI-QWEN3_TTS** to the default channel so they can be installed without changing security settings
- Fix existing **CRT-Nodes** entry: restore missing `author`/`title` fields, update `plugcrypt` → `PGCRT` (GitHub username change), remove redundant `reference2`