### PR TITLE
Add ComfyUI-Image-to-Prompt-Abacus.AI- custom node entry (kplkasteel)

### DIFF
--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -45563,6 +45563,33 @@
             ],
             "install_type": "unzip",
             "description": "This is a node to convert an image into a CMYK Halftone dot image."
+        },
+        {
+            "author": "kplkasteel",
+            "title": "Image to Prompt (Abacus.AI)",
+            "id": "comfyui-image-to-prompt-abacusai",
+            "reference": "https://github.com/kplkasteel/ComfyUI-Image-to-Prompt-Abacus.AI-",
+            "files": [
+                "https://github.com/kplkasteel/ComfyUI-Image-to-Prompt-Abacus.AI-"
+            ],
+            "install_type": "git-clone",
+            "description": "ComfyUI custom node that converts an input image into a Stable Diffusion-ready prompt using Abacus.AI’s OpenAI-compatible multimodal API (model dropdown fetched from /v1/models; supports route-llm and other available models). Requires an Abacus.AI API key and consumes API credits.",
+            "tags": [
+                "prompt",
+                "image-to-prompt",
+                "vision",
+                "multimodal",
+                "captioning",
+                "stable-diffusion",
+                "abacus-ai",
+                "api"
+            ],
+            "pip": [
+                "openai",
+                "requests",
+                "pillow",
+                "numpy"
+            ]
         }
     ]
 }


### PR DESCRIPTION
Adds Image to Prompt (Abacus.AI) to the ComfyUI-Manager custom node list.

What this node does
Provides a ComfyUI custom node that converts an input IMAGE into a Stable Diffusion-ready text prompt by calling Abacus.AI’s OpenAI-compatible multimodal API. The node fetches available models from /v1/models (defaulting to route-llm) and returns the generated prompt as a STRING.

Install / Usage
Install via ComfyUI-Manager (this entry) or by cloning the repo into ComfyUI/custom_nodes/
Requires the following pip deps: openai, requests, pillow, numpy
Requires an Abacus.AI API key and will consume Abacus.AI credits per request
Repo
[kplkasteel/ComfyUI-Image-to-Prompt-Abacus.AI-](vscode-file://vscode-app/c:/Program%20Files/AbacusAI/resources/app/out/vs/code/electron-browser/workbench/workbench.html)