### PR TITLE
Add ComfyUI-NVML-Monitor

### DIFF
--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -1,6 +1,16 @@
 {
     "custom_nodes": [
         {
+            "author": "robomello",
+            "title": "ComfyUI-NVML-Monitor",
+            "reference": "https://github.com/robomello/ComfyUI-NVML-Monitor",
+            "files": [
+                "https://github.com/robomello/ComfyUI-NVML-Monitor"
+            ],
+            "install_type": "git-clone",
+            "description": "NVIDIA-first hardware telemetry chip + popup for ComfyUI. Linux/Docker-friendly with explicit accounting for VRAM used by other containers/host."
+        },
+        {
             "author": "Carasibana",
             "title": "ComfyUI-SimpleFloatSlider",
             "reference": "https://github.com/Carasibana/ComfyUI-SimplayboyleFloatSlider",


### PR DESCRIPTION
Adds [ComfyUI-NVML-Monitor](https://github.com/robomello/ComfyUI-NVML-Monitor) to the registry.

**What it does:** NVIDIA-first hardware telemetry node. Adds a draggable floating chip in ComfyUI showing CPU%, RAM, VRAM, and GPU utilization, plus a click-to-expand popup with detailed GPU stats (utilization, temperature, power draw vs limit, clocks, fan, processes) and a System tab (per-core CPU mini-bars, RAM, driver).

**Why another monitor:** existing options like ComfyUI-ADLX-Monitor (AMD/Windows) and ComfyUI-XPUSYS-Monitor (cross-vendor) target different use cases. This one is built specifically for NVIDIA + Linux, often running inside Docker. It uses `pynvml`/`nvidia-ml-py` directly and includes explicit accounting for VRAM held by external containers/host processes that NVML inside a container cannot attribute to a visible PID — surfaced as a clear "External (other containers / host)" row in the popup's process table.

**Implementation:**
- Backend: Python (`monitor.py`) with 500 ms server-side cache, thread-safe
- Frontend: vanilla JS, no build step, single `web/nvml_monitor.js`
- HTTP API: `GET /nvml_monitor/stats` returning a JSON snapshot
- License: MIT
- Initial release: [v0.1.0](https://github.com/robomello/ComfyUI-NVML-Monitor/releases/tag/v0.1.0)

Tested on RTX PRO 6000 Blackwell (driver 595.58.03) on Linux 6.17 with ComfyUI in Docker. Multi-GPU code path exists but currently single-GPU tested.

Repo: https://github.com/robomello/ComfyUI-NVML-Monitor