### PR TITLE
Add comfyui-spectrum-ksampler node to custom-node-list.json

### DIFF
--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -52645,6 +52645,16 @@
             ],
             "install_type": "git-clone",
             "description": "A growing collection of EmberFrame utility nodes for Comfy, including advanced PiD sampling, Z-Image/Flux latent normalization, wildcard prompt helpers, and resolution tools."
+        },
+        {
+            "author": "sorryhyun",
+            "title": "SpectrumKSampler",
+            "reference": "https://github.com/sorryhyun/ComfyUI-Spectrum-KSampler",
+            "files": [
+                "https://github.com/sorryhyun/ComfyUI-Spectrum-KSampler"
+            ],
+            "install_type": "git-clone",
+            "description": "Spectrum: training-free diffusion sampling acceleration via Chebyshev polynomial feature forecasting. Drop-in KSampler replacement that skips transformer blocks on predicted steps for ~2-3x speedup."
         }
     ]
 }


### PR DESCRIPTION
Hello, I want to add comfyui-spectrum-ksampler node, which integrates spectrum and modulation guidance in proper way with convenient UX. There're more than 900 downloads recently in [comfy registry](https://registry.comfy.org/ko/publishers/sorryhyun/nodes/comfyui-spectrum-ksampler) so I hope this to be comfyui-manager bundled.