### PR TITLE
Add ComfyUI-Switchboard (Group/Node Controllers)

### DIFF
--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -52845,6 +52845,16 @@
             ],
             "install_type": "unzip",
             "description": "This is a node to convert an image into a CMYK Halftone dot image."
+        },
+        {
+            "author": "Oratrorian",
+            "title": "ComfyUI-Switchboard",
+            "reference": "https://github.com/Oratorian/ComfyUI-Switchboard",
+            "files": [
+                "https://github.com/Oratorian/ComfyUI-Switchboard"
+            ],
+            "install_type": "git-clone",
+            "description": "Client-side nodes for enabling/disabling parts of your graph - by hand or from a wired boolean. A more flexible take on rgthree's Fast Group Bypasser. Two nodes, identical behaviour, different target."
         }
     ]
 }


### PR DESCRIPTION
 ### Add ComfyUI-Switchboard to the custom node list

  Adds a single entry to `custom-node-list.json` for **ComfyUI-Switchboard**.

  **Repository:** https://github.com/Oratorian/comfyui-switchboard

  #### What it is
  Two client-side ("virtual") nodes for enabling/disabling parts of a graph, a
  more flexible take on rgthree's *Fast Group Bypasser*:

  - **Group Controller** - toggle whole **groups** on/off, by title.
  - **Node Controller** - toggle **individual nodes** on/off, by id.

  Each target gets an on/off toggle plus an independent **bypass / mute** selector,
  a master broadcast toggle, and an optional `BOOLEAN` input that drives its state
  (a connected boolean overrides the master toggle). State survives save/load and
  is re-applied at queue time.

  #### Notes
  - Pure front-end JavaScript - **no Python dependencies**, nothing runs on the server.
  - `install_type`: `git-clone`.
  - Works on the legacy LiteGraph renderer and loads under Nodes 2.0 (Vue) via the
    compatibility layer.

  #### Checklist
  - [x] Added one entry to `custom-node-list.json`
  - [x] `reference` and `files` point to the public GitHub repo
  - [x] Repo contains a valid `pyproject.toml` (`name = "comfyui-switchboard"`), `LICENSE`, and `README.md`
  - [x] JSON validated (no trailing-comma / syntax errors)