### PR TITLE
fix(git_compat): harden pygit2 fallback path; prefer system git when available

### DIFF
--- a/comfyui_manager/common/git_compat.py
+++ b/comfyui_manager/common/git_compat.py
@@ -447,6 +447,28 @@ class _Pygit2Repo(GitRepo):
         self._repo = _pygit2.Repository(git_dir)
         self._working_dir = repo_path
 
+    def _fetch_remote(self, remote, refspecs=None):
+        """Fetch *remote* over the preserved proxy, transparently rewriting an
+        SSH-form origin to anonymous HTTPS in memory.
+
+        The bundled pygit2 has no SSH transport, so a stored `git@host:...`
+        origin would fail with an auth error. When the URL is SSH-form we fetch
+        through an in-memory anonymous remote over HTTPS, leaving `.git/config`
+        untouched (no on-disk rewrite).
+        """
+        https_url = _to_https_url(remote.url)
+        if https_url != remote.url:
+            anon = self._repo.remotes.create_anonymous(https_url)
+            anon.fetch(
+                list(refspecs) if refspecs is not None
+                else list(remote.fetch_refspecs),
+                proxy=_HTTP_PROXY,
+            )
+        elif refspecs is not None:
+            remote.fetch(list(refspecs), proxy=_HTTP_PROXY)
+        else:
+            remote.fetch(proxy=_HTTP_PROXY)
+
     @property
     def working_dir(self):
         return self._working_dir
@@ -503,7 +525,7 @@ class _Pygit2Repo(GitRepo):
         remote = self._repo.remotes[name]
 
         def _pull():
-            remote.fetch(proxy=_HTTP_PROXY)
+            self._fetch_remote(remote)
             branch_name = self.active_branch_name
             branch = self._repo.branches.get(branch_name)
             if branch and branch.upstream:
@@ -516,7 +538,7 @@ class _Pygit2Repo(GitRepo):
                         branch_ref.set_target(remote_commit.id)
                     self._repo.head.set_target(remote_commit.id)
 
-        return _RemoteProxy(remote.name, remote.url, remote.fetch, _pull)
+        return _RemoteProxy(remote.name, remote.url, lambda: self._fetch_remote(remote), _pull)
 
     def has_ref(self, ref_name):
         for prefix in [f'refs/remotes/{ref_name}', f'refs/heads/{ref_name}',
@@ -713,7 +735,7 @@ class _Pygit2Repo(GitRepo):
             raise GitCommandError(f"No upstream for branch '{branch_name}'")
 
         remote_name = upstream.remote_name
-        self._repo.remotes[remote_name].fetch(proxy=_HTTP_PROXY)
+        self._fetch_remote(self._repo.remotes[remote_name])
 
         upstream = self._repo.branches.get(branch_name).upstream
         if upstream is None:
@@ -838,12 +860,12 @@ class _Pygit2Repo(GitRepo):
 
     def fetch_remote_by_index(self, index):
         remotes = list(self._repo.remotes)
-        remotes[index].fetch(proxy=_HTTP_PROXY)
+        self._fetch_remote(remotes[index])
 
     def pull_remote_by_index(self, index):
         remotes = list(self._repo.remotes)
         remote = remotes[index]
-        remote.fetch(proxy=_HTTP_PROXY)
+        self._fetch_remote(remote)
         # After fetch, try to ff-merge tracking branch
         try:
             branch_name = self.active_branch_name

--- a/comfyui_manager/common/git_compat.py
+++ b/comfyui_manager/common/git_compat.py
@@ -14,10 +14,27 @@ Exports:
 """
 
 import os
+import re
 import sys
 from abc import ABC, abstractmethod
 from collections import deque
 from datetime import datetime, timezone, timedelta
+
+
+def _to_https_url(url):
+    """Rewrite an SSH-form git URL to its anonymous HTTPS equivalent.
+
+    Handles `git@host:owner/repo(.git)` and `ssh://git@host/owner/repo(.git)`.
+    Returns the URL unchanged if it is not SSH-form, so pygit2 clone/fetch
+    of public repos never requires SSH credentials even when a repo's own
+    config stores an SSH origin.
+    """
+    if not url:
+        return url
+    m = re.match(r"^(?:ssh://)?git@([^:/]+)[:/](.+)$", url)
+    if m:
+        return "https://%s/%s" % (m.group(1), m.group(2))
+    return url
 
 # ---------------------------------------------------------------------------
 # Backend selection
@@ -48,6 +65,27 @@ if USE_PYGIT2:
         # may be owned by a different user (e.g., system-installed paths).
         # See CVE-2022-24765 for context on this validation.
         _pygit2.option(_pygit2.GIT_OPT_SET_OWNER_VALIDATION, 0)
+
+        # Ignore system/global/XDG git config for libgit2 operations. A
+        # user's global config can carry `insteadOf` rewrites (e.g.
+        # https->ssh) or credential helpers that force authentication,
+        # which libgit2 cannot satisfy without a credentials callback
+        # ("authentication required but no callback set"). Blanking the
+        # config search path keeps clone/fetch over anonymous HTTPS.
+        try:
+            from pygit2.enums import ConfigLevel as _ConfigLevel
+            _cfg_levels = [_ConfigLevel.SYSTEM, _ConfigLevel.XDG, _ConfigLevel.GLOBAL]
+        except (ImportError, AttributeError):
+            _cfg_levels = [
+                _pygit2.GIT_CONFIG_LEVEL_SYSTEM,
+                _pygit2.GIT_CONFIG_LEVEL_XDG,
+                _pygit2.GIT_CONFIG_LEVEL_GLOBAL,
+            ]
+        for _lvl in _cfg_levels:
+            try:
+                _pygit2.settings.search_path[_lvl] = ""
+            except Exception:
+                pass
 
 if not USE_PYGIT2:
     import git as _git
@@ -387,6 +425,18 @@ class _Pygit2Repo(GitRepo):
                 pass
         self._repo = _pygit2.Repository(git_dir)
         self._working_dir = repo_path
+        self._normalize_remote_urls()
+
+    def _normalize_remote_urls(self):
+        """Rewrite any SSH-form remote URLs to anonymous HTTPS so fetch/pull
+        never require SSH credentials under the pygit2 backend."""
+        for remote in self._repo.remotes:
+            https_url = _to_https_url(remote.url)
+            if https_url != remote.url:
+                try:
+                    self._repo.remotes.set_url(remote.name, https_url)
+                except Exception:
+                    pass
 
     @property
     def working_dir(self):
@@ -824,7 +874,7 @@ def clone_repo(url, dest, progress=None):
     (checkout, clear_cache, close, etc.).
     """
     if USE_PYGIT2:
-        _pygit2.clone_repository(url, dest)
+        _pygit2.clone_repository(_to_https_url(url), dest)
         repo = _Pygit2Repo(dest)
         repo.submodule_update()
         return repo

--- a/comfyui_manager/common/git_compat.py
+++ b/comfyui_manager/common/git_compat.py
@@ -446,18 +446,6 @@ class _Pygit2Repo(GitRepo):
                 pass
         self._repo = _pygit2.Repository(git_dir)
         self._working_dir = repo_path
-        self._normalize_remote_urls()
-
-    def _normalize_remote_urls(self):
-        """Rewrite any SSH-form remote URLs to anonymous HTTPS so fetch/pull
-        never require SSH credentials under the pygit2 backend."""
-        for remote in self._repo.remotes:
-            https_url = _to_https_url(remote.url)
-            if https_url != remote.url:
-                try:
-                    self._repo.remotes.set_url(remote.name, https_url)
-                except Exception:
-                    pass
 
     @property
     def working_dir(self):

--- a/comfyui_manager/common/git_compat.py
+++ b/comfyui_manager/common/git_compat.py
@@ -21,6 +21,13 @@ from collections import deque
 from datetime import datetime, timezone, timedelta
 
 
+# Snapshot of the user's global `http.proxy` (captured before the config
+# search path is blanked under the pygit2 backend) so corporate proxy
+# settings survive and can be passed explicitly to fetch/clone. None means
+# "no proxy".
+_HTTP_PROXY = None
+
+
 def _to_https_url(url):
     """Rewrite an SSH-form git URL to its anonymous HTTPS equivalent.
 
@@ -66,12 +73,26 @@ if USE_PYGIT2:
         # See CVE-2022-24765 for context on this validation.
         _pygit2.option(_pygit2.GIT_OPT_SET_OWNER_VALIDATION, 0)
 
+        # Snapshot the global http.proxy BEFORE blanking the config search
+        # path, so a corporate proxy survives and can be passed explicitly
+        # to clone/fetch below.
+        try:
+            _global_cfg = _pygit2.Config.get_global_config()
+            try:
+                _HTTP_PROXY = _global_cfg["http.proxy"] or None
+            except (KeyError, Exception):
+                _HTTP_PROXY = None
+        except Exception:
+            _HTTP_PROXY = None
+
         # Ignore system/global/XDG git config for libgit2 operations. A
         # user's global config can carry `insteadOf` rewrites (e.g.
         # https->ssh) or credential helpers that force authentication,
         # which libgit2 cannot satisfy without a credentials callback
-        # ("authentication required but no callback set"). Blanking the
-        # config search path keeps clone/fetch over anonymous HTTPS.
+        # ("authentication required but no callback set"). The bundled
+        # pygit2 has no SSH transport, so an SSH rewrite can never succeed;
+        # blanking the config search path keeps clone/fetch on anonymous
+        # HTTPS.
         try:
             from pygit2.enums import ConfigLevel as _ConfigLevel
             _cfg_levels = [_ConfigLevel.SYSTEM, _ConfigLevel.XDG, _ConfigLevel.GLOBAL]
@@ -494,7 +515,7 @@ class _Pygit2Repo(GitRepo):
         remote = self._repo.remotes[name]
 
         def _pull():
-            remote.fetch()
+            remote.fetch(proxy=_HTTP_PROXY)
             branch_name = self.active_branch_name
             branch = self._repo.branches.get(branch_name)
             if branch and branch.upstream:
@@ -704,7 +725,7 @@ class _Pygit2Repo(GitRepo):
             raise GitCommandError(f"No upstream for branch '{branch_name}'")
 
         remote_name = upstream.remote_name
-        self._repo.remotes[remote_name].fetch()
+        self._repo.remotes[remote_name].fetch(proxy=_HTTP_PROXY)
 
         upstream = self._repo.branches.get(branch_name).upstream
         if upstream is None:
@@ -829,12 +850,12 @@ class _Pygit2Repo(GitRepo):
 
     def fetch_remote_by_index(self, index):
         remotes = list(self._repo.remotes)
-        remotes[index].fetch()
+        remotes[index].fetch(proxy=_HTTP_PROXY)
 
     def pull_remote_by_index(self, index):
         remotes = list(self._repo.remotes)
         remote = remotes[index]
-        remote.fetch()
+        remote.fetch(proxy=_HTTP_PROXY)
         # After fetch, try to ff-merge tracking branch
         try:
             branch_name = self.active_branch_name
@@ -874,7 +895,7 @@ def clone_repo(url, dest, progress=None):
     (checkout, clear_cache, close, etc.).
     """
     if USE_PYGIT2:
-        _pygit2.clone_repository(_to_https_url(url), dest)
+        _pygit2.clone_repository(_to_https_url(url), dest, proxy=_HTTP_PROXY)
         repo = _Pygit2Repo(dest)
         repo.submodule_update()
         return repo


### PR DESCRIPTION
## Summary

Hardens the **pygit2 fallback path** in `git_compat.py`. Paired with Comfy-Org/Comfy-Desktop#1038, which is the actual fix for the Desktop update/migration failure (Comfy-Desktop#1036).

> Targets `manager-v4` (not shipped on `main` yet).

### Context
The bundled pygit2/libgit2 honors the user's global git config but ships **HTTPS-only (no SSH transport)**. A global `insteadOf` rewrite (`https://github.com/` ? `git@github.com:`) makes pygit2 fetch/clone fail with `authentication required but no callback set`.

Manager's backend selection already does the right thing and is **unchanged** here:

```
USE_PYGIT2 = (CM_USE_PYGIT2 == '1')   # only when explicitly forced
if not USE_PYGIT2:
    try: git --version                 # probe system git via GitPython
    except: USE_PYGIT2 = True          # pygit2 only when system git is absent
```

Since Comfy-Desktop#1038 stops forcing `CM_USE_PYGIT2`, Manager now **prefers system git (GitPython) whenever it's present** - which honors the user's full config (`insteadOf`, proxy, ssh keys, credential helpers) and sidesteps the bug entirely. There's no real reason to prefer pygit2 when system git exists, so we don't.

### What this PR changes (fallback path only)
pygit2 is now reached only as a no-system-git fallback (or when a developer sets `COMFY_FORCE_PYGIT2=1`). To keep that path robust:

- **Ignore system/global/XDG git config** for libgit2 ops (in-memory `search_path` blanking). Protects the no-git box that still has a stray `~/.gitconfig` with an `insteadOf` rewrite (e.g. from GitHub Desktop or synced dotfiles), which would otherwise reproduce the identical failure.
- **Preserve corporate `http.proxy`** - snapshot it before blanking and pass it explicitly to clone/fetch, so config blanking doesn't strip a corporate proxy.

All changes live inside the `if USE_PYGIT2:` path, so they are inert whenever system git is available.

### Not destructive
Removed the earlier on-disk remote-URL rewrite (`_normalize_remote_urls`): persistently rewriting a repo's stored `origin` is risky if interrupted and unnecessary given the config blanking. Everything here is in-memory only.