### PR TITLE
Add AtlasCloud_ComfyUI to custom-node-list.json

### DIFF
--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -60978,6 +60978,17 @@
             ],
             "install_type": "git-clone",
             "description": "Creative suite for ComfyUI: fullscreen Image Composer, Paint, 3D Builder, Image Crop and AudioReact editors, plus Load/Save Image, Save Mp4, Load Video, Inpaint Crop and Stitch, Outpaint, XY Plot, Prompt library, LoRA Loader, Control Panel, Notes, Labels, and canvas tools for aligning and grouping nodes."
+        },
+        {
+            "author": "AtlasCloudAI",
+            "title": "AtlasCloud_ComfyUI",
+            "id": "atlascloud_comfyui",
+            "reference": "https://github.com/AtlasCloudAI/atlascloud_comfyui",
+            "files": [
+                "https://github.com/AtlasCloudAI/atlascloud_comfyui"
+            ],
+            "install_type": "git-clone",
+            "description": "Nodes for running Atlas Cloud's hosted AI models inside ComfyUI without a local GPU or model weights: text-to-image, image edit, text-to-video and image-to-video via Seedance 2.0, Kling 3, Sora 2, Veo 3.1, Wan 2.7, Nano Banana 2/Pro, GPT Image 2, Flux 2 and Seedream 5, plus LLM chat and TTS nodes. Requires an Atlas Cloud API key."
         }
     ]
 }


### PR DESCRIPTION
Registers `AtlasCloudAI/atlascloud_comfyui` in `custom-node-list.json`.

The node pack calls Atlas Cloud's hosted inference API, so the nodes run without local model weights or a GPU: text-to-image, image edit, text-to-video and image-to-video (Seedance 2.0, Kling 3, Sora 2, Veo 3.1, Wan 2.7, Nano Banana 2/Pro, GPT Image 2, Flux 2, Seedream 5), plus LLM chat and TTS nodes. An Atlas Cloud API key is required.

Repo: https://github.com/AtlasCloudAI/atlascloud_comfyui
`install_type` is `git-clone`; `requirements.txt` is present for automatic dependency install.

JSON validated with `python -m json.tool` after the change (single entry appended, no other lines touched).