### PR TITLE
Add Comfy-MSS to custom-node-list.json

### DIFF
--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -60978,6 +60978,16 @@
             ],
             "install_type": "git-clone",
             "description": "Creative suite for ComfyUI: fullscreen Image Composer, Paint, 3D Builder, Image Crop and AudioReact editors, plus Load/Save Image, Save Mp4, Load Video, Inpaint Crop and Stitch, Outpaint, XY Plot, Prompt library, LoRA Loader, Control Panel, Notes, Labels, and canvas tools for aligning and grouping nodes."
+        },
+        {
+            "author": "pymss-project",
+            "title": "Comfy-MSS",
+            "reference": "https://github.com/pymss-project/comfy-mss",
+            "files": [
+                "https://github.com/pymss-project/comfy-mss"
+            ],
+            "install_type": "git-clone",
+            "description": "Comfy-MSS provides ComfyUI nodes for music source separation powered by [pymss](https://github.com/pymss-project/pymss). It supports both built-in pymss model catalog entries and user-provided MSST models, allowing workflows to separate an input audio track into stems such as vocals, instrumental, drums, bass, and other sources."
         }
     ]
 }


### PR DESCRIPTION
Add Comfy-MSS to custom-node-list.json

repo url: [https://github.com/pymss-project/comfy-mss](https://github.com/pymss-project/comfy-mss)

ComfyUI-MSS provides ComfyUI nodes for music source separation powered by [pymss](https://github.com/pymss-project/pymss). It supports both built-in pymss model catalog entries and user-provided MSST models, allowing workflows to separate an input audio track into stems such as vocals, instrumental, drums, bass, and other sources.

### Included nodes

- `MSS Separate`: separates a ComfyUI `AUDIO` stream with catalog MSS/non-VR pymss models.
- `MSS Separate List`: list-output variant of MSS Separate.
- `Custom MSS Separate`: separates audio with user-provided MSS models from the custom model folder.
- `Custom MSS Separate List`: list-output variant of `Custom MSS Separate`.
- `VR Separate`: separates a ComfyUI `AUDIO` stream with VR/UVR pymss models.
- `VR Separate List`: list-output variant of `VR Separate`.
- `MSS Params`: optional parameter input for `MSS Separate` and `Custom MSS Separate`.
- `VR Params`: optional parameter input for `VR Separate`.
- `Load Audio`: loads one audio file and outputs both the audio stream and the file name without extension.
- ~`Load Audio Batch`: loads audio files from a folder as ComfyUI list outputs.~
- `Audio Invert Phase`: inverts audio input `a` and outputs `-a`.
- `Audio Normalize`: normalizes only when the peak is above 0 dBFS.
- `Audio Ensemble`: combines 2 to 10 audio inputs with selectable ensemble algorithms and weights.
- `Save Audio`: saves ComfyUI `AUDIO` streams as `wav`, `flac`, or `mp3`.

For more details, visit [https://github.com/pymss-project/comfy-mss](https://github.com/pymss-project/comfy-mss)