### PR TITLE
Add DenRakEiw_Nodes to custom node list

### DIFF
--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -34566,6 +34566,16 @@
             "description": "ComfyUI custom node that converts input image dimensions to the nearest recommended Qwen-Image resolution preset, matching orientation and aspect ratio while optimizing for the target model."
         },
         {
+            "author": "DenRakEiw",
+            "title": "DenRakEiw Nodes",
+            "reference": "https://github.com/DenRakEiw/DenRakEiw_Nodes",
+            "files": [
+                "https://github.com/DenRakEiw/DenRakEiw_Nodes"
+            ],
+            "install_type": "git-clone",
+            "description": "ComfyUI node pack with latent color match and image adjust tools, a universal neural-network latent upscaler (SD1.5/SDXL/Flux/Wan2.2), Flux LayerDiffuse transparent image generation, a multi-image aspect ratio composer, and Flux 3 API nodes. Integrates the standalone Latent_Nodes and WAN_NN_Latent_Upscale packs (DRE-tagged to coexist without conflicts)."
+        },
+        {
             "author": "RainyN0077",
             "title": "ComfyUI-PromptSE",
             "id": "comfyui-promptse",


### PR DESCRIPTION
## Adds DenRakEiw_Nodes to the custom node list

**Repository:** https://github.com/DenRakEiw/DenRakEiw_Nodes

### What the pack provides

ComfyUI node pack by DenRakEiw with:
- **Latent Color Match** and **Latent Image Adjust** tools (kornia + color-matcher based)
- **Universal NN Latent Upscaler** supporting SD1.5, SDXL, Flux, and Wan2.2 models (bundled .pt models, based on Ttl's ComfyUi_NNLatentUpscale)
- **Flux LayerDiffuse** transparent image generation system
- **Multi-Image Aspect Ratio Composer** with face-detection and smart-grid layouts
- **Flux 3 API** nodes (BFL video API + OpenRouter prompt generator)

### Note on coexistence

This pack integrates the standalone [Latent_Nodes](https://github.com/DenRakEiw/Latent_Nodes) and [WAN_NN_Latent_Upscale](https://github.com/DenRakEiw/WAN_NN_Latent_Upscale) packs. The integrated nodes use an internal `_DRE` suffix and a `*DRE` display-name tag, so both the standalone packs and this combined pack can coexist in the same ComfyUI install without node-ID conflicts.

### Verification

- JSON validated after insertion
- Entry follows the same schema as existing DenRakEiw entries (Latent_Nodes, WAN_NN_Latent_Upscale, ComfyUI-nearest-qwen-resolution)
- `install_type: git-clone` — clone path resolves to `custom_nodes/DenRakEiw_Nodes`
