### PR TITLE
Add OpenH3-IR to custom-node-list.json

### DIFF
--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -9,7 +9,7 @@
                 "https://github.com/ruashots/open-h3-ir"
             ],
             "install_type": "git-clone",
-            "description": "Three nodes: type a sentence, get the long Context-IR prompt document MiniMax H3 actually wants, checked before it renders. Needs the OpenH3-IR service from this repo running: h3ir serve."
+            "description": "Three nodes: type a sentence, get the Context-IR document MiniMax H3 wants, in their own published format, checked first. Needs this repo's OpenH3-IR service (h3ir serve) and any OpenAI-compatible model you already run."
         },
         {
             "author": "Carasibana",

--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -9,7 +9,7 @@
                 "https://github.com/ruashots/ComfyUI-OpenH3-IR"
             ],
             "install_type": "git-clone",
-            "description": "Four nodes: type a prompt, get the brief MiniMax H3 actually wants, in its own published format, checked before it runs. A tray for your pictures, clips and sounds, an @ prompt that points at them, and a director for how it is written. Needs the OpenH3-IR service (h3ir serve) and any OpenAI-compatible model you already run."
+            "description": "Four nodes for MiniMax H3: type a plain prompt, name your pictures, clips and sounds with @, lock exact dialogue, and get the structured brief H3 wants in its own published format, checked before it runs. Nothing to start beside ComfyUI. Needs any OpenAI-compatible model you run or have access to."
         },
         {
             "author": "Carasibana",

--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -1,6 +1,17 @@
 {
     "custom_nodes": [
         {
+            "author": "ruashots",
+            "title": "OpenH3-IR",
+            "id": "open-h3-ir",
+            "reference": "https://github.com/ruashots/open-h3-ir",
+            "files": [
+                "https://github.com/ruashots/open-h3-ir"
+            ],
+            "install_type": "git-clone",
+            "description": "Three nodes: type a sentence, get the long Context-IR prompt document MiniMax H3 actually wants, checked before it renders. Needs the OpenH3-IR service from this repo running: h3ir serve."
+        },
+        {
             "author": "Carasibana",
             "title": "ComfyUI-SimpleFloatSlider",
             "reference": "https://github.com/Carasibana/ComfyUI-SimplayboyleFloatSlider",

--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -3,13 +3,13 @@
         {
             "author": "ruashots",
             "title": "OpenH3-IR",
-            "id": "open-h3-ir",
-            "reference": "https://github.com/ruashots/open-h3-ir",
+            "id": "comfyui-openh3-ir",
+            "reference": "https://github.com/ruashots/ComfyUI-OpenH3-IR",
             "files": [
-                "https://github.com/ruashots/open-h3-ir"
+                "https://github.com/ruashots/ComfyUI-OpenH3-IR"
             ],
             "install_type": "git-clone",
-            "description": "Three nodes: type a sentence, get the Context-IR document MiniMax H3 wants, in their own published format, checked first. Needs this repo's OpenH3-IR service (h3ir serve) and any OpenAI-compatible model you already run."
+            "description": "Four nodes: type a prompt, get the brief MiniMax H3 actually wants, in its own published format, checked before it runs. A tray for your pictures, clips and sounds, an @ prompt that points at them, and a director for how it is written. Needs the OpenH3-IR service (h3ir serve) and any OpenAI-compatible model you already run."
         },
         {
             "author": "Carasibana",


### PR DESCRIPTION
Adds the ComfyUI node pack for OpenH3-IR.

MiniMax published the format for H3's Context-IR document, the long structured prompt the model
actually wants, along with finished examples of it. What they kept on their own servers is the part
that writes it. OpenH3-IR is an open take on that part. It is not a prompt enhancer. It writes the
document to MiniMax's published format, with the named sections in a fixed order, numbered picture
labels, a length on H3's frame grid, per-shot cut times, and sound described separately. None of
that is left to the model to get right. The structure is computed rather than asked for, the
finished document is validated against the format, and one that does not hold is refused and
written again.

**The four nodes this repository ships.** They are how OpenH3-IR is used from ComfyUI, and they
bring the compiler with them, so the pack is the whole thing rather than a front end for something
you install separately. Main takes the prompt and hands the render the model, conditioning, latent and
both VAEs, so the graph needs no loader boxes and no H3 conditioning node. Media is one tray for
pictures, clips and sounds, each carrying the name the prompt refers to it by. Setup holds the
language model address and the five H3 files. Director is optional reusable direction.

Repo: https://github.com/ruashots/ComfyUI-OpenH3-IR (Apache-2.0)

**What a reviewer should know.**

*Dependencies.* `requirements.txt` declares one package, `open-h3-ir`, published on PyPI under
Apache-2.0. Manager's pip step installs it. Nothing is vendored, and no copy of the compiler lives
in this repository, so either half can be updated on its own.

*Nothing to start.* The compiler runs inside ComfyUI's own Python. There is no service to launch and
no port to pick. Pointing the graph at an OpenH3-IR instance on another machine over HTTP stays
available and is not the normal path.

*The one thing a user needs* is an OpenAI-compatible model endpoint they run or have access to:
vLLM, llama.cpp server, LM Studio, Ollama, or a hosted one. No cloud account is required, and the
compiler wants no GPU of its own. If the endpoint is missing or down, the node says which and names
the field to fill in.

*The import is lazy.* The nodes do not import the compiler while ComfyUI is loading them. A missing,
half-installed or broken `open-h3-ir` costs the compile rather than the pack: the nodes still appear
on the menu, and the failure is reported when a graph tries to compile.

*Install shape.* The repository root is the pack. A git-clone into `custom_nodes` loads as-is, with
no subfolder and no re-export.

**Checks.** 519 tests in this pack and 990 in the compiler, all of them with no model, no GPU and no
network. MiniMax's own published examples are in the compiler's test set and have to pass clean,
because a check that fires on their own artifact is a wrong check. This pack also carries a harness
that plants 113 deliberate defects one at a time and requires the guard for each one to fail.
