### PR TITLE
Add ComfyUI-FeiHou-Easy-H3

### DIFF
--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -1,6 +1,17 @@
 {
     "custom_nodes": [
         {
+            "author": "FX-FeiHou",
+            "title": "ComfyUI-FeiHou-Easy-H3",
+            "id": "comfyui-feihou-easy-h3",
+            "reference": "https://github.com/FX-FeiHou/ComfyUI-FeiHou-Easy-H3",
+            "files": [
+                "https://github.com/FX-FeiHou/ComfyUI-FeiHou-Easy-H3"
+            ],
+            "install_type": "git-clone",
+            "description": "MiniMax H3 generation nodes for ComfyUI with an embedded 9-image, 3-video, and 3-audio reference gallery, LoRA stack support, optional second-pass sampling, and prompt optimization."
+        },
+        {
             "author": "Carasibana",
             "title": "ComfyUI-SimpleFloatSlider",
             "reference": "https://github.com/Carasibana/ComfyUI-SimplayboyleFloatSlider",


### PR DESCRIPTION
## Summary

- Adds the standard edition only; the RunningHub (RH) edition is intentionally not included.
- Registry ID: comfyui-feihou-easy-h3
- Repository: https://github.com/FX-FeiHou/ComfyUI-FeiHou-Easy-H3

## Validation

- Parsed custom-node-list.json successfully after adding the entry.