### PR TITLE
Add ComfyUI-WeeLLM to custom node list

### DIFF
--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -61154,6 +61154,16 @@
             ],
             "install_type": "git-clone",
             "description": "ComfyUI nodes for Krea 2 AnyPaint arbitrary-mask inpainting and outpainting"
+        },
+        {
+            "author": "Jit-Roy",
+            "title": "ComfyUI-WeeLLM",
+            "reference": "https://github.com/Jit-Roy/ComfyUI-WeeLLM",
+            "files": [
+                "https://github.com/Jit-Roy/ComfyUI-WeeLLM"
+            ],
+            "install_type": "git-clone",
+            "description": "Native ComfyUI integration for WeeLLM: Run multi-billion parameter diffusion models (FLUX, SD3, MiniMax) under 4GB VRAM using layer-streaming inference."
         }
     ]
 }


### PR DESCRIPTION
Adding ComfyUI-WeeLLM to the registry. This is a native wrapper for the WeeLLM layer-streaming inference engine, allowing users to run large diffusion models under 4GB of VRAM.