### PR TITLE
add MiniMax H3 Combined Model Loader to custom node list

### DIFF
--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -61154,6 +61154,16 @@
             ],
             "install_type": "git-clone",
             "description": "ComfyUI nodes for Krea 2 AnyPaint arbitrary-mask inpainting and outpainting"
+        },
+        {
+            "author": "entropicnoise",
+            "title": "MiniMax H3 Combined Model Loader",
+            "reference": "https://github.com/entropicnoise/MiniMax-H3-Combined-Model-Loader",
+            "files": [
+                "https://github.com/entropicnoise/MiniMax-H3-Combined-Model-Loader"
+            ],
+            "install_type": "git-clone",
+            "description": "A single ComfyUI loader node for MiniMax H3 FL2VA and REF2VA diffusion models, for combined i2i+ref2i inference using ComfyUi MiniMax H3 Image And Reference To Video node."
         }
     ]
 }


### PR DESCRIPTION
- Repository: https://github.com/entropicnoise/MiniMax-H3-Combined-Model-Loader
- Node: MiniMaxH3HybridModelLoader (MiniMaxH3HybridModelLoader)
- Description: A single ComfyUI loader node for MiniMax H3 FL2VA and REF2VA diffusion models, for combined i2i+ref2i inference using ComfyUi MiniMax H3 Image And Reference To Video node.