### PR TITLE
Add H3 Prompt IDE

### DIFF
--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -1,6 +1,17 @@
 {
     "custom_nodes": [
         {
+            "author": "ethanfel",
+            "title": "H3 Prompt IDE",
+            "id": "h3-prompt-ide",
+            "reference": "https://github.com/ethanfel/ComfyUI-H3-Prompt-IDE",
+            "files": [
+                "https://github.com/ethanfel/ComfyUI-H3-Prompt-IDE"
+            ],
+            "install_type": "git-clone",
+            "description": "VS Code-inspired MiniMax H3 prompt editor with strict prompt sections, completions, reference media previews, and plain STRING output."
+        },
+        {
             "author": "Carasibana",
             "title": "ComfyUI-SimpleFloatSlider",
             "reference": "https://github.com/Carasibana/ComfyUI-SimplayboyleFloatSlider",


### PR DESCRIPTION
Adds H3 Prompt IDE to custom-node-list.json.\n\n- Repository: https://github.com/ethanfel/ComfyUI-H3-Prompt-IDE\n- Registry ID: h3-prompt-ide\n- Publisher: ethanfel\n- License: GPL-3.0-only\n- Registry version: 0.5.0 uploaded\n- Validation: JSON parses successfully and the entry is unique