### PR TITLE
Add Model Fetcher (comfyui-modelfetcher)

### DIFF
--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -61154,6 +61154,17 @@
             ],
             "install_type": "git-clone",
             "description": "ComfyUI nodes for Krea 2 AnyPaint arbitrary-mask inpainting and outpainting"
+        },
+        {
+            "author": "KoLt-Real",
+            "title": "Model Fetcher",
+            "id": "comfyui-modelfetcher",
+            "reference": "https://github.com/KoLt-Real/ComfyUI-ModelFetcher",
+            "files": [
+                "https://github.com/KoLt-Real/ComfyUI-ModelFetcher"
+            ],
+            "install_type": "git-clone",
+            "description": "Top-bar button that reads a workflow's Markdown notes, downloads the models it needs into the right folder, and relinks loader nodes to copies you already own."
         }
     ]
 }


### PR DESCRIPTION
Adds **Model Fetcher**, already published on the Comfy Registry: https://registry.comfy.org/nodes/comfyui-modelfetcher

- Repository: https://github.com/KoLt-Real/ComfyUI-ModelFetcher
- Registers no nodes: a top-bar button that reads the open workflow's Markdown notes, downloads the models they list into the right `models/` subfolder (extra_model_paths aware, resume, HuggingFace token kept to HF hosts only), flags likely duplicates, and relinks loader nodes to copies already on disk.
- No dependencies beyond what ComfyUI ships (`requests`, `aiohttp`); no build step; `comfy node validate` passes clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)