### PR TITLE
Add ComfyUI Prompt Bookmarks

### DIFF
--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -61154,6 +61154,16 @@
             ],
             "install_type": "git-clone",
             "description": "ComfyUI nodes for Krea 2 AnyPaint arbitrary-mask inpainting and outpainting"
+        },
+        {
+            "author": "vdeng-ai",
+            "title": "ComfyUI Prompt Bookmarks",
+            "reference": "https://github.com/vdeng-ai/ComfyUI-Prompt-Bookmarks",
+            "files": [
+                "https://github.com/vdeng-ai/ComfyUI-Prompt-Bookmarks"
+            ],
+            "install_type": "git-clone",
+            "description": "Lightweight, dependency-free ComfyUI sidebar for bookmarking, organizing, searching, copying, and restoring personal prompts without adding workflow nodes."
         }
     ]
 }

--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -61469,6 +61469,16 @@
             ],
             "install_type": "unzip",
             "description": "This is a node to convert an image into a CMYK Halftone dot image."
+        },
+        {
+            "author": "vdeng-ai",
+            "title": "ComfyUI Prompt Bookmarks",
+            "reference": "https://github.com/vdeng-ai/ComfyUI-Prompt-Bookmarks",
+            "files": [
+                "https://github.com/vdeng-ai/ComfyUI-Prompt-Bookmarks"
+            ],
+            "install_type": "git-clone",
+            "description": "Lightweight, dependency-free ComfyUI sidebar for bookmarking, organizing, searching, copying, and restoring personal prompts without adding workflow nodes."
         }
     ]
 }


### PR DESCRIPTION
Adds ComfyUI Prompt Bookmarks to the Manager custom node list.

- Repository: https://github.com/vdeng-ai/ComfyUI-Prompt-Bookmarks
- Latest release: v0.2.1
- Lightweight, dependency-free, sidebar-only prompt organizer
- Registers no inference nodes and does not modify workflow graphs
- Stores user data outside the custom-node repository
- Uses ComfyUI official custom-node locale support for multilingual UI

Validation:
- `custom-node-list.json` parses successfully with `python -m json.tool`
- `git diff --check` passes
- Only `custom-node-list.json` is changed
- Plugin v0.2.1 CI passes on Python 3.10, 3.11, and 3.12 with frontend syntax checks