### PR TITLE
add MiniMax H3 Combined Image And Reference to Video

### DIFF
--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -61154,6 +61154,16 @@
             ],
             "install_type": "git-clone",
             "description": "ComfyUI nodes for Krea 2 AnyPaint arbitrary-mask inpainting and outpainting"
+        },
+        {
+            "author": "entropicnoise",
+            "title": "MiniMax H3 Combined Image And Reference to Video",
+            "reference": "https://github.com/entropicnoise/MiniMax-H3-Combined-Image-And-Reference-to-Video",
+            "files": [
+                "https://github.com/entropicnoise/MiniMax-H3-Combined-Image-And-Reference-to-Video"
+            ],
+            "install_type": "git-clone",
+            "description": "A ComfyUI custom node that combines MiniMax H3 target-frame image conditioning and Ref2VA reference conditioning in a single node."
         }
     ]
 }


### PR DESCRIPTION
- Repository: https://github.com/entropicnoise/MiniMax-H3-Combined-Image-And-Reference-to-Video
- Node: MiniMaxH3CombinedImageAndReferenceToVideo (MiniMaxH3CombinedImageAndReferenceToVideo)
- Description: A ComfyUI custom node that combines MiniMax H3 target-frame image conditioning and Ref2VA reference conditioning in a single node.