### PR TITLE
Add ComfyUI Free Model and Node Cache to custom-node-list.json

### DIFF
--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -61154,6 +61154,17 @@
             ],
             "install_type": "git-clone",
             "description": "ComfyUI nodes for Krea 2 AnyPaint arbitrary-mask inpainting and outpainting"
+        },
+        {
+            "author": "VRAM-Hoarder",
+            "title": "ComfyUI Free Model and Node Cache",
+            "reference": "https://github.com/VRAM-Hoarder/ComfyUI-Free_model_and_node_cache",
+            "files": [
+                "https://github.com/VRAM-Hoarder/ComfyUI-Free_model_and_node_cache"
+            ],
+            "install_type": "git-clone",
+            "description": "A ComfyUI custom node that replicates the function of the -Free model and node cache- toolbar button, usable INLINE in a workflow, so you can force a VRAM/RAM cleanup automatically after every generation instead of clicking a button manually."
         }
+
     ]
 }

--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -61165,6 +61165,5 @@
             "install_type": "git-clone",
             "description": "A ComfyUI custom node that replicates the function of the -Free model and node cache- toolbar button, usable INLINE in a workflow, so you can force a VRAM/RAM cleanup automatically after every generation instead of clicking a button manually."
         }
-
     ]
 }


### PR DESCRIPTION
A ComfyUI custom node that replicates the function of the 'Free model and node cache' toolbar button - usable inline in a workflow, so you can force a VRAM/RAM cleanup automatically after every generation instead of clicking a button manually.