### PR TITLE
Add Qwen3.8 VL

### DIFF
--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -61154,6 +61154,17 @@
             ],
             "install_type": "git-clone",
             "description": "ComfyUI nodes for Krea 2 AnyPaint arbitrary-mask inpainting and outpainting"
+        },
+        {
+            "author": "xzbdqian10nian",
+            "title": "Qwen3.8 VL",
+            "id": "qwen38-vl",
+            "reference": "https://github.com/xzbdqian10nian/ComfyUI-Qwen3.8-VL",
+            "files": [
+                "https://github.com/xzbdqian10nian/ComfyUI-Qwen3.8-VL"
+            ],
+            "install_type": "git-clone",
+            "description": "Qwen3.8 VL multimodal vision-language nodes for ComfyUI. Supports local GGUF inference through llama.cpp and OpenAI-compatible API backends for text, images, image batches, and video frames."
         }
     ]
 }


### PR DESCRIPTION
## Summary
- Add the Qwen3.8 VL ComfyUI custom node pack to the legacy Manager index.
- The repository includes local GGUF/llama.cpp inference and OpenAI-compatible API backends.

## Validation
- `python3 json-checker.py custom-node-list.json` passes.
- Repository is public and the referenced URL is the renamed canonical repository.

Repository: https://github.com/xzbdqian10nian/ComfyUI-Qwen3.8-VL