### PR TITLE
Update Universal Model Loader listing for metadata hotfix

### DIFF
--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -60802,7 +60802,7 @@
                 "https://github.com/Zoltar358-ComfyUI/ComfyUI-Universal-Model-Loader"
             ],
             "install_type": "git-clone",
-            "description": "Universal ComfyUI model loader for checkpoints, diffusers, diffusion models, UNet, GGUF, dual CLIP outputs and dual VAE outputs with dynamic UI, Registry Node Pack Info previews, and auto CLIP type detection for latest model families including MiniMax Music3/MM3."
+            "description": "Universal ComfyUI model loader for checkpoints, diffusers, diffusion models, UNet, GGUF, dual CLIP outputs and dual VAE outputs with dynamic UI, Registry Node Pack Info previews, saved-workflow metadata cleanup, and auto CLIP type detection for latest model families including MiniMax Music3/MM3."
         },
         {
             "author": "StyleRef",

--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -60802,7 +60802,7 @@
                 "https://github.com/Zoltar358-ComfyUI/ComfyUI-Universal-Model-Loader"
             ],
             "install_type": "git-clone",
-            "description": "Universal ComfyUI model loader for checkpoints, diffusers, diffusion models, UNet, GGUF, dual CLIP outputs and dual VAE outputs with dynamic UI, Registry Node Pack Info previews, saved-workflow metadata cleanup, and auto CLIP type detection for latest model families including MiniMax Music3/MM3."
+            "description": "Universal ComfyUI model loader for checkpoints, diffusers, diffusion models, UNet, GGUF, dual CLIP outputs and dual VAE outputs with dynamic UI, Registry Node Pack Info previews, selected-model metadata cleanup, and auto CLIP type detection for latest model families including MiniMax Music3/MM3."
         },
         {
             "author": "StyleRef",

--- a/node_db/new/custom-node-list.json
+++ b/node_db/new/custom-node-list.json
@@ -440,7 +440,7 @@
                 "https://github.com/Zoltar358-ComfyUI/ComfyUI-Universal-Model-Loader"
             ],
             "install_type": "git-clone",
-            "description": "Universal ComfyUI model loader for checkpoints, diffusers, diffusion models, UNet, GGUF, dual CLIP outputs and dual VAE outputs with dynamic UI, Registry Node Pack Info previews, saved-workflow metadata cleanup, and auto CLIP type detection for latest model families including MiniMax Music3/MM3."
+            "description": "Universal ComfyUI model loader for checkpoints, diffusers, diffusion models, UNet, GGUF, dual CLIP outputs and dual VAE outputs with dynamic UI, Registry Node Pack Info previews, selected-model metadata cleanup, and auto CLIP type detection for latest model families including MiniMax Music3/MM3."
         },
         {
             "author": "kkukshtel",

--- a/node_db/new/custom-node-list.json
+++ b/node_db/new/custom-node-list.json
@@ -440,7 +440,7 @@
                 "https://github.com/Zoltar358-ComfyUI/ComfyUI-Universal-Model-Loader"
             ],
             "install_type": "git-clone",
-            "description": "Universal ComfyUI model loader for checkpoints, diffusers, diffusion models, UNet, GGUF, dual CLIP outputs and dual VAE outputs with dynamic UI, Registry Node Pack Info previews, and auto CLIP type detection for latest model families including MiniMax Music3/MM3."
+            "description": "Universal ComfyUI model loader for checkpoints, diffusers, diffusion models, UNet, GGUF, dual CLIP outputs and dual VAE outputs with dynamic UI, Registry Node Pack Info previews, saved-workflow metadata cleanup, and auto CLIP type detection for latest model families including MiniMax Music3/MM3."
         },
         {
             "author": "kkukshtel",


### PR DESCRIPTION
## Summary

- Update ComfyUI Universal Model Loader listing for the v1.0.8 hotfix
- Mention selected-model metadata cleanup alongside dual CLIP/VAE outputs, Registry Node Pack Info previews, and MiniMax Music3/MM3 support

## Context

GitHub release: https://github.com/Zoltar358-ComfyUI/ComfyUI-Universal-Model-Loader/releases/tag/v1.0.8

Registry package/API: https://api.comfy.org/nodes/universal-model-loader

Changes in v1.0.8:
- Keeps inactive hidden model selectors valid for ComfyUI's execution serializer.
- Still writes `null` for inactive hidden selectors in saved workflow metadata.
- Fixes the queue-time “Invalid input / Some input values are not available for this node” regression while preserving selected-model PNG metadata cleanup.

## Validation

- JSON syntax validated for `custom-node-list.json`
- JSON syntax validated for `node_db/new/custom-node-list.json`
- Nodepack validation passed: JS syntax, Python compile, `comfy node validate`, frontend execution+metadata serialization simulation, and local `/object_info/UniversalModelLoader`
