### PR TITLE
Add ValiTools node pack

### DIFF
--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -1,6 +1,16 @@
 {
     "custom_nodes": [
         {
+            "author": "Valentin Klein",
+            "title": "ValiTools",
+            "reference": "https://github.com/vangel76/comfyui-ValiTools",
+            "files": [
+                "https://github.com/vangel76/comfyui-ValiTools"
+            ],
+            "install_type": "git-clone",
+            "description": "ValiTools node collection: VSmartPrompt (Dynamic Prompts with a rich-text editor, reusable variables, switcher conditions, chaining inputs and post-run selection highlighting), VFileRandom (no-repeat random image loader), VRandomSelector (lazy random passthrough of N same-type inputs) and VWaitForVRAM (hold execution until enough VRAM is free)."
+        },
+        {
             "author": "Carasibana",
             "title": "ComfyUI-SimpleFloatSlider",
             "reference": "https://github.com/Carasibana/ComfyUI-SimplayboyleFloatSlider",


### PR DESCRIPTION
Adds the ValiTools node collection to `custom-node-list.json`.

The pack is published on the Comfy Registry but is not in this list yet, so it shows up without stars or last-update information in the Manager.

**Nodes**
- **VSmartPrompt** — Dynamic Prompts with a rich-text editor: combinations with weights, wildcards, reusable variables (rolled once, constant everywhere), switcher conditions, chaining inputs, and post-run highlighting of the branches that were actually selected
- **VFileRandom** — random image loader that never repeats until every image in the folder has been drawn
- **VRandomSelector** — lazy random passthrough of N same-type inputs; only the selected branch executes
- **VWaitForVRAM** — holds execution until the GPU has a minimum amount of free VRAM

Repository: https://github.com/vangel76/comfyui-ValiTools
Registry: https://registry.comfy.org/publishers/vangel/nodes/valitools
License: Apache-2.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)