### PR TITLE
Add ComfyUI Prompt Feeder node

### DIFF
--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -61469,6 +61469,16 @@
             ],
             "install_type": "unzip",
             "description": "This is a node to convert an image into a CMYK Halftone dot image."
+        },
+        {
+            "author": "ketle-man",
+            "title": "ComfyUI Prompt Feeder",
+            "reference": "https://github.com/ketle-man/comfyui-prompt-feeder",
+            "files": [
+                "https://github.com/ketle-man/comfyui-prompt-feeder"
+            ],
+            "install_type": "git-clone",
+            "description": "A ComfyUI custom node for looping through text prompts one at a time, with two input modes: typing directly on the node, or selecting .txt files from a built-in 3-pane library (folder tree, file list, and in-place preview/editor). Supports presets, natural/random sorting, and registering read-only external paths to reuse existing prompt/wildcard .txt data from other node packs."
         }
     ]
 }


### PR DESCRIPTION
## Summary
Adds an entry for [ComfyUI Prompt Feeder](https://github.com/ketle-man/comfyui-prompt-feeder) (MIT licensed, v0.1.0) to `custom-node-list.json`.

A custom node that feeds text prompts from a folder one at a time, with:
- `edit` mode (type directly on the node) and `library` mode (pick `.txt` files from a folder)
- A 3-pane Prompt Library for browsing/creating/editing/renaming `.txt` files, with presets
- Natural/descending/random (seeded) sorting and per-file range control
- Read-only "external paths" registration to reuse existing prompt/wildcard `.txt` data from other node packs
- i18n: English / 日本語 / 中文（简体）

## Test plan
- [x] Validated `custom-node-list.json` still parses as valid JSON after the addition
- [x] Confirmed the diff only adds the new entry (no reformatting of surrounding content)
- [x] Verified the repository is public, MIT licensed, and has a tagged v0.1.0 release

🤖 Generated with [Claude Code](https://claude.com/claude-code)