### PR TITLE
Add MSCH Nodes as one unified custom-node pack

### DIFF
--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -1,6 +1,156 @@
 {
     "custom_nodes": [
         {
+            "author": "mariobilly",
+            "title": "MSCH A2V",
+            "reference": "https://github.com/mariobilly/msch-a2v",
+            "files": [
+                "https://github.com/mariobilly/msch-a2v"
+            ],
+            "install_type": "git-clone",
+            "description": "Beat-synced prompt sequencing, shot planning, MiniMax H3 sampling, assembly and pixel upscaling for music videos."
+        },
+        {
+            "author": "mariobilly",
+            "title": "MSCH Code Matrix",
+            "reference": "https://github.com/mariobilly/msch-code-matrix",
+            "files": [
+                "https://github.com/mariobilly/msch-code-matrix"
+            ],
+            "install_type": "git-clone",
+            "description": "Convert images and video frames into ASCII portraits, binary art and animated Matrix-style glyph patterns."
+        },
+        {
+            "author": "mariobilly",
+            "title": "MSCH Edge ASCII",
+            "reference": "https://github.com/mariobilly/msch-edge-ascii",
+            "files": [
+                "https://github.com/mariobilly/msch-edge-ascii"
+            ],
+            "install_type": "git-clone",
+            "description": "Contour-aligned ASCII strokes, halftone fills and animated marks for photos and native ComfyUI video."
+        },
+        {
+            "author": "mariobilly",
+            "title": "MSCH Lyric Sync",
+            "reference": "https://github.com/mariobilly/msch-lyric-sync",
+            "files": [
+                "https://github.com/mariobilly/msch-lyric-sync"
+            ],
+            "install_type": "git-clone",
+            "description": "Align pasted lyrics to audio and render bilingual captions or animated lyric mosaics with editable color palettes."
+        },
+        {
+            "author": "mariobilly",
+            "title": "MSCH MCP Bridge",
+            "reference": "https://github.com/mariobilly/msch-mcp-bridge",
+            "files": [
+                "https://github.com/mariobilly/msch-mcp-bridge"
+            ],
+            "install_type": "git-clone",
+            "description": "Local ComfyUI browser bridge for changing widget values, setting node modes and reading the current graph."
+        },
+        {
+            "author": "mariobilly",
+            "title": "MSCH Pointillism",
+            "reference": "https://github.com/mariobilly/msch-pointillism",
+            "files": [
+                "https://github.com/mariobilly/msch-pointillism"
+            ],
+            "install_type": "git-clone",
+            "description": "Animate color-sampled dots over paper with distortion, ink bleed, grain and frame-hold controls."
+        },
+        {
+            "author": "mariobilly",
+            "title": "MSCH Puppet Face",
+            "reference": "https://github.com/mariobilly/msch-puppet-face",
+            "files": [
+                "https://github.com/mariobilly/msch-puppet-face"
+            ],
+            "install_type": "git-clone",
+            "description": "Face landmark and animated cursor overlays with self-contained OpenCV video loading and MP4 saving."
+        },
+        {
+            "author": "mariobilly",
+            "title": "MSCH Scan FX",
+            "reference": "https://github.com/mariobilly/msch-scanfx",
+            "files": [
+                "https://github.com/mariobilly/msch-scanfx"
+            ],
+            "install_type": "git-clone",
+            "description": "Stack up to eight thermal, night-vision, hologram, HUD, radar, glitch and other scan effects inside an optional mask."
+        },
+        {
+            "author": "mariobilly",
+            "title": "MSCH Slideshow",
+            "reference": "https://github.com/mariobilly/msch-slideshow",
+            "files": [
+                "https://github.com/mariobilly/msch-slideshow"
+            ],
+            "install_type": "git-clone",
+            "description": "Photo slideshow studio with animated layouts, beat analysis, subject framing, editable shot plans and streamed video export."
+        },
+        {
+            "author": "mariobilly",
+            "title": "MSCH Slideshow Forge",
+            "reference": "https://github.com/mariobilly/msch-slideshow-forge",
+            "files": [
+                "https://github.com/mariobilly/msch-slideshow-forge"
+            ],
+            "install_type": "git-clone",
+            "description": "Build editable photo timelines and render procedural Ken Burns motion and transitions using PyTorch and Kornia."
+        },
+        {
+            "author": "mariobilly",
+            "title": "MSCH Synkit FX",
+            "reference": "https://github.com/mariobilly/msch-synkitfx",
+            "files": [
+                "https://github.com/mariobilly/msch-synkitfx"
+            ],
+            "install_type": "git-clone",
+            "description": "Animated metaball halftones and feature-tracking HUD boxes with labels, connectors, native VIDEO and overlay masks."
+        },
+        {
+            "author": "mariobilly",
+            "title": "MSCH Theme",
+            "reference": "https://github.com/mariobilly/msch-theme",
+            "files": [
+                "https://github.com/mariobilly/msch-theme"
+            ],
+            "install_type": "git-clone",
+            "description": "Apply the MSCH carbon, steel, bone and acid-accent palette to compatible custom node cards."
+        },
+        {
+            "author": "mariobilly",
+            "title": "MSCH TimeSlice",
+            "reference": "https://github.com/mariobilly/msch-timeslice",
+            "files": [
+                "https://github.com/mariobilly/msch-timeslice"
+            ],
+            "install_type": "git-clone",
+            "description": "Temporal displacement of video bands and cubes with time-offset color ramps, RGB spread and jitter."
+        },
+        {
+            "author": "mariobilly",
+            "title": "MSCH Typort",
+            "reference": "https://github.com/mariobilly/msch-typort",
+            "files": [
+                "https://github.com/mariobilly/msch-typort"
+            ],
+            "install_type": "git-clone",
+            "description": "Layered animated typography studio with Arabic text, keyframes, audio reactions and transparent or composite exports."
+        },
+        {
+            "author": "mariobilly",
+            "title": "MSCH Warp Wiggle",
+            "reference": "https://github.com/mariobilly/msch-warp-wiggle",
+            "files": [
+                "https://github.com/mariobilly/msch-warp-wiggle"
+            ],
+            "install_type": "git-clone",
+            "description": "Warped transitions between video clips, animated single-clip distortion and matching HUD overlays."
+        },
+        {
             "author": "Carasibana",
             "title": "ComfyUI-SimpleFloatSlider",
             "reference": "https://github.com/Carasibana/ComfyUI-SimplayboyleFloatSlider",

--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -45004,7 +45004,7 @@
             "install_type": "git-clone",
             "description": "Passthrough node that instantly unloads any running ollama model mid workflow. No API calls, just accepts plain string as a model name and executes 'ollama stop <model>' command in your system."
         },
-		{
+        {
             "author": "DemonAlone",
             "title": "DemonAlone-nodes-ComfyUI",
             "reference": "https://github.com/DemonAlone/DemonAlone-nodes-ComfyUI",
@@ -45014,7 +45014,7 @@
             "install_type": "git-clone",
             "description": "A collection of nodes that provide dynamic dropdown selectors for Samplers, Schedulers, Checkpoints, and Diffusion Models, outputting a comma-separated string for use in XY plots."
         },
-		{
+        {
             "author": "DemonAlone",
             "title": "DemonAlone-StyleSelector-ComfyUI",
             "reference": "https://github.com/DemonAlone/DemonAlone-StyleSelector-ComfyUI",

--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -45004,7 +45004,7 @@
             "install_type": "git-clone",
             "description": "Passthrough node that instantly unloads any running ollama model mid workflow. No API calls, just accepts plain string as a model name and executes 'ollama stop <model>' command in your system."
         },
-        {
+		{
             "author": "DemonAlone",
             "title": "DemonAlone-nodes-ComfyUI",
             "reference": "https://github.com/DemonAlone/DemonAlone-nodes-ComfyUI",
@@ -45014,7 +45014,7 @@
             "install_type": "git-clone",
             "description": "A collection of nodes that provide dynamic dropdown selectors for Samplers, Schedulers, Checkpoints, and Diffusion Models, outputting a comma-separated string for use in XY plots."
         },
-        {
+		{
             "author": "DemonAlone",
             "title": "DemonAlone-StyleSelector-ComfyUI",
             "reference": "https://github.com/DemonAlone/DemonAlone-StyleSelector-ComfyUI",
@@ -45024,7 +45024,7 @@
             "install_type": "git-clone",
             "description": "Prompt Style Selector with Preview, Multiple Selecting, Search and Local Base."
         },
-        {
+		{
             "author": "DemonAlone",
             "title": "DemonAlone-JS_Addon-ComfyUI",
             "reference": "https://github.com/DemonAlone/DemonAlone-JS_Addon-ComfyUI",
@@ -60741,10 +60741,7 @@
             ],
             "install_type": "git-clone",
             "description": "Professional ACES and EXR workflow nodes with OCIO 2.1 support and sequence loading.",
-            "pip": [
-                "opencolorio>=2.2.0",
-                "openexr>=3.2.0"
-            ]
+            "pip": ["opencolorio>=2.2.0", "openexr>=3.2.0"]
         },
         {
             "author": "Neurad",

--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -2,153 +2,13 @@
     "custom_nodes": [
         {
             "author": "mariobilly",
-            "title": "MSCH A2V",
-            "reference": "https://github.com/mariobilly/msch-a2v",
+            "title": "MSCH Nodes",
+            "reference": "https://github.com/mariobilly/msch-comfyui-nodes",
             "files": [
-                "https://github.com/mariobilly/msch-a2v"
+                "https://github.com/mariobilly/msch-comfyui-nodes"
             ],
             "install_type": "git-clone",
-            "description": "Beat-synced prompt sequencing, shot planning, MiniMax H3 sampling, assembly and pixel upscaling for music videos."
-        },
-        {
-            "author": "mariobilly",
-            "title": "MSCH Code Matrix",
-            "reference": "https://github.com/mariobilly/msch-code-matrix",
-            "files": [
-                "https://github.com/mariobilly/msch-code-matrix"
-            ],
-            "install_type": "git-clone",
-            "description": "Convert images and video frames into ASCII portraits, binary art and animated Matrix-style glyph patterns."
-        },
-        {
-            "author": "mariobilly",
-            "title": "MSCH Edge ASCII",
-            "reference": "https://github.com/mariobilly/msch-edge-ascii",
-            "files": [
-                "https://github.com/mariobilly/msch-edge-ascii"
-            ],
-            "install_type": "git-clone",
-            "description": "Contour-aligned ASCII strokes, halftone fills and animated marks for photos and native ComfyUI video."
-        },
-        {
-            "author": "mariobilly",
-            "title": "MSCH Lyric Sync",
-            "reference": "https://github.com/mariobilly/msch-lyric-sync",
-            "files": [
-                "https://github.com/mariobilly/msch-lyric-sync"
-            ],
-            "install_type": "git-clone",
-            "description": "Align pasted lyrics to audio and render bilingual captions or animated lyric mosaics with editable color palettes."
-        },
-        {
-            "author": "mariobilly",
-            "title": "MSCH MCP Bridge",
-            "reference": "https://github.com/mariobilly/msch-mcp-bridge",
-            "files": [
-                "https://github.com/mariobilly/msch-mcp-bridge"
-            ],
-            "install_type": "git-clone",
-            "description": "Local ComfyUI browser bridge for changing widget values, setting node modes and reading the current graph."
-        },
-        {
-            "author": "mariobilly",
-            "title": "MSCH Pointillism",
-            "reference": "https://github.com/mariobilly/msch-pointillism",
-            "files": [
-                "https://github.com/mariobilly/msch-pointillism"
-            ],
-            "install_type": "git-clone",
-            "description": "Animate color-sampled dots over paper with distortion, ink bleed, grain and frame-hold controls."
-        },
-        {
-            "author": "mariobilly",
-            "title": "MSCH Puppet Face",
-            "reference": "https://github.com/mariobilly/msch-puppet-face",
-            "files": [
-                "https://github.com/mariobilly/msch-puppet-face"
-            ],
-            "install_type": "git-clone",
-            "description": "Face landmark and animated cursor overlays with self-contained OpenCV video loading and MP4 saving."
-        },
-        {
-            "author": "mariobilly",
-            "title": "MSCH Scan FX",
-            "reference": "https://github.com/mariobilly/msch-scanfx",
-            "files": [
-                "https://github.com/mariobilly/msch-scanfx"
-            ],
-            "install_type": "git-clone",
-            "description": "Stack up to eight thermal, night-vision, hologram, HUD, radar, glitch and other scan effects inside an optional mask."
-        },
-        {
-            "author": "mariobilly",
-            "title": "MSCH Slideshow",
-            "reference": "https://github.com/mariobilly/msch-slideshow",
-            "files": [
-                "https://github.com/mariobilly/msch-slideshow"
-            ],
-            "install_type": "git-clone",
-            "description": "Photo slideshow studio with animated layouts, beat analysis, subject framing, editable shot plans and streamed video export."
-        },
-        {
-            "author": "mariobilly",
-            "title": "MSCH Slideshow Forge",
-            "reference": "https://github.com/mariobilly/msch-slideshow-forge",
-            "files": [
-                "https://github.com/mariobilly/msch-slideshow-forge"
-            ],
-            "install_type": "git-clone",
-            "description": "Build editable photo timelines and render procedural Ken Burns motion and transitions using PyTorch and Kornia."
-        },
-        {
-            "author": "mariobilly",
-            "title": "MSCH Synkit FX",
-            "reference": "https://github.com/mariobilly/msch-synkitfx",
-            "files": [
-                "https://github.com/mariobilly/msch-synkitfx"
-            ],
-            "install_type": "git-clone",
-            "description": "Animated metaball halftones and feature-tracking HUD boxes with labels, connectors, native VIDEO and overlay masks."
-        },
-        {
-            "author": "mariobilly",
-            "title": "MSCH Theme",
-            "reference": "https://github.com/mariobilly/msch-theme",
-            "files": [
-                "https://github.com/mariobilly/msch-theme"
-            ],
-            "install_type": "git-clone",
-            "description": "Apply the MSCH carbon, steel, bone and acid-accent palette to compatible custom node cards."
-        },
-        {
-            "author": "mariobilly",
-            "title": "MSCH TimeSlice",
-            "reference": "https://github.com/mariobilly/msch-timeslice",
-            "files": [
-                "https://github.com/mariobilly/msch-timeslice"
-            ],
-            "install_type": "git-clone",
-            "description": "Temporal displacement of video bands and cubes with time-offset color ramps, RGB spread and jitter."
-        },
-        {
-            "author": "mariobilly",
-            "title": "MSCH Typort",
-            "reference": "https://github.com/mariobilly/msch-typort",
-            "files": [
-                "https://github.com/mariobilly/msch-typort"
-            ],
-            "install_type": "git-clone",
-            "description": "Layered animated typography studio with Arabic text, keyframes, audio reactions and transparent or composite exports."
-        },
-        {
-            "author": "mariobilly",
-            "title": "MSCH Warp Wiggle",
-            "reference": "https://github.com/mariobilly/msch-warp-wiggle",
-            "files": [
-                "https://github.com/mariobilly/msch-warp-wiggle"
-            ],
-            "install_type": "git-clone",
-            "description": "Warped transitions between video clips, animated single-clip distortion and matching HUD overlays."
+            "description": "One install for the full MSCH collection: 35 video effects, slideshow, typography, lyric-sync and MiniMax H3 nodes, plus theme and editor bridge. Replaces the separate msch-* packs."
         },
         {
             "author": "Carasibana",
@@ -45164,7 +45024,7 @@
             "install_type": "git-clone",
             "description": "Prompt Style Selector with Preview, Multiple Selecting, Search and Local Base."
         },
-		{
+        {
             "author": "DemonAlone",
             "title": "DemonAlone-JS_Addon-ComfyUI",
             "reference": "https://github.com/DemonAlone/DemonAlone-JS_Addon-ComfyUI",
@@ -60881,7 +60741,10 @@
             ],
             "install_type": "git-clone",
             "description": "Professional ACES and EXR workflow nodes with OCIO 2.1 support and sequence loading.",
-            "pip": ["opencolorio>=2.2.0", "openexr>=3.2.0"]
+            "pip": [
+                "opencolorio>=2.2.0",
+                "openexr>=3.2.0"
+            ]
         },
         {
             "author": "Neurad",


### PR DESCRIPTION
Register **MSCH Nodes** as one installable pack at https://github.com/mariobilly/msch-comfyui-nodes.

The repository contains all 35 existing MSCH node IDs and the theme/editor bridge in one package. Node implementations, full references, workflow examples and rendered showcases are organized by component. The root loader isolates component failures and detects known legacy installations to avoid duplicate node, route and frontend registrations. MIGRATION.md explains switching from the former separate packs without changing workflow node IDs.

Validation: the actual ComfyUI custom-node loader registered all 35 nodes under the unified package; all 15 components and six frontend entry points loaded; HTTP checks covered the entry points, editor, font and sequencer assets; Code Matrix and Typort smoke renders passed; six loader tests and all 108 existing A2V core tests passed. GitHub checks also validate syntax, metadata, workflow JSON and browser import paths.

This submission adds one Manager entry. The earlier proposed 15 separate entries have been replaced in this branch. Historical repositories link to the new pack for migration.
