### PR TITLE
Register ComfyUI-FEnodes custom node

### DIFF
--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -1,6 +1,16 @@
 {
     "custom_nodes": [
         {
+            "author": "FugitiveExpert01",
+            "title": "ComfyUI-FEnodes",
+            "reference": "https://github.com/FugitiveExpert01/ComfyUI-FEnodes",
+            "files": [
+                "https://github.com/FugitiveExpert01/ComfyUI-FEnodes"
+            ],
+            "install_type": "git-clone",
+            "description": "Tiling and text utility nodes for VFX production pipelines in ComfyUI."
+        },
+        {
             "author": "Carasibana",
             "title": "ComfyUI-SimpleFloatSlider",
             "reference": "https://github.com/Carasibana/ComfyUI-SimplayboyleFloatSlider",


### PR DESCRIPTION
Adds an entry for ComfyUI-FEnodes to custom-node-list.json.

- Repo: https://github.com/FugitiveExpert01/ComfyUI-FEnodes
- Description: Tiling and text utility nodes for VFX production pipelines in ComfyUI.
- Already published on Comfy Registry as enodes (publisher: latentiq).
- Verified custom-node-list.json remains valid JSON after the change.