### PR TITLE
Add: custom nodes of DiffSynth-Studio

### DIFF
--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -61469,6 +61469,16 @@
             ],
             "install_type": "unzip",
             "description": "This is a node to convert an image into a CMYK Halftone dot image."
+        },
+        {
+            "author": "modelscope",
+            "title": "DiffSynth-ComfyUI",
+            "reference": "https://github.com/modelscope/DiffSynth-ComfyUI",
+            "files": [
+                "https://github.com/modelscope/DiffSynth-ComfyUI"
+            ],
+            "install_type": "git-clone",
+            "description": "A ComfyUI custom node plugin for DiffSynth-Studio, enabling low-VRAM inference through configurable VRAM management, NF4 quantization, and model offloading. Supports image, video, and audio generation and editing across 20+ diffusion models."
         }
     ]
 }


### PR DESCRIPTION
Adds DiffSynth-ComfyUI to `custom-node-list.json`.

The plugin integrates [DiffSynth-Studio](https://github.com/modelscope/DiffSynth-Studio) (an open-source diffusion framework by **ModelScope**) into ComfyUI, enabling low-VRAM inference through configurable VRAM management, NF4/int8 quantization, and model offloading for 20+ diffusion models.

**Nodes**

- **VRAMConfig** — device/dtype strategy per phase, enabling inference on GPUs with limited VRAM
- **QuantizationConfig** — NF4/int8 dynamic quantization with per-module exclude support; also supports pre-quantized weight loading
- **ModelConfig** — model source and file pattern specification, with optional VRAM config and quant config attached
- **MergeModelConfigs** — combines multiple model configs into a single list for the loader
- **LoRALoad / LoRAClear** — multi-LoRA loading with configurable alpha and target module, with chaining support
- **PipelineLoader** — dynamically generated per model (Z-Image, Qwen-Image, Flux, Wan Video, MiniMax-H3, ACE-Step, etc.)
- **PipelineInference** — dynamically generated per model, exposes all inference parameters as ComfyUI widgets

**Workflows**

40 prebuilt workflow templates with thumbnail previews:
- **4 featured workflows**: Z-Image-Turbo NF4, Qwen-Image-Edit-2511-Lightning, MiniMax-H3 Pruned NF4, ACE-Step 1.5 XL SFT
- **36 general workflows**: text-to-image, image editing, text-to-video, image-to-video, text-to-audio, image-to-audio across 20+ model series

Framework: https://github.com/modelscope/DiffSynth-Studio
Repository: https://github.com/modelscope/DiffSynth-ComfyUI
License: Apache-2.0