### PR TITLE
Add Antimeter YuE2 Local Runtime

### DIFF
--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -11,6 +11,18 @@
             "description": "ComfyUI custom nodes providing styled draggable float slider widgets"
         },
         {
+            "author": "AntiMatterComfy",
+            "title": "Antimeter YuE2 Local Runtime",
+            "id": "antimeter-yue2-local-runtime",
+            "nodename_pattern": "AntimeterYuE2",
+            "reference": "https://github.com/AntiMatterComfy/antimeter-yue2-local-runtime",
+            "files": [
+                "https://github.com/AntiMatterComfy/antimeter-yue2-local-runtime"
+            ],
+            "install_type": "git-clone",
+            "description": "Local YuE2 music generation for ComfyUI with Windows WSL and native Linux installers plus NVIDIA GPU preflight. The node package installs through Manager; the local YuE2 runtime and model weights are installed separately by the documented platform installer."
+        },
+        {
             "author": "18yz153",
             "title": "ComfyUI-Persona-Director",
             "reference": "https://github.com/c/ComfyUI-Persona-Director",


### PR DESCRIPTION
Adds the public AntiMatterComfy YuE2 integration to the Manager catalogue. The Manager installation clones only the custom-node package. YuE2's separately documented Windows WSL or native Linux installer performs the explicit local GPU check and installs the official runtime; it is not run automatically by Manager.\n\nRepository: https://github.com/AntiMatterComfy/antimeter-yue2-local-runtime\nRecommended release: https://github.com/AntiMatterComfy/antimeter-yue2-local-runtime/releases/tag/v1.1.2\n\nThe node has no bundled weights. Upstream YuE2 model weights remain under CC BY-NC 4.0.