### PR TITLE
Add ComfyUI-CNCC (ControlNet Control Center) node

### DIFF
--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -61453,6 +61453,17 @@
             ],
             "install_type": "unzip",
             "description": "This is a node to convert an image into a CMYK Halftone dot image."
+        },
+        {
+            "author": "ketle-man",
+            "title": "ComfyUI-CNCC (ControlNet Control Center)",
+            "id": "comfyui-cncc",
+            "reference": "https://github.com/ketle-man/ComfyUI-CNCC",
+            "files": [
+                "https://github.com/ketle-man/ComfyUI-CNCC"
+            ],
+            "install_type": "git-clone",
+            "description": "Nodes: CNCC ControlNet, CNCC Apply ControlNet. Saves comfyui_controlnet_aux preprocessors as reusable presets, and lets a single node run the preprocessor and apply the result as a ControlNet (a drop-in alternative to the native Apply ControlNet node). Includes a settings modal for creating/managing presets from a thumbnail gallery."
         }
     ]
 }


### PR DESCRIPTION
## Summary

Adds an entry for [ComfyUI-CNCC](https://github.com/ketle-man/ComfyUI-CNCC) (ControlNet Control Center) to `custom-node-list.json`.

CNCC saves `comfyui_controlnet_aux` preprocessors as reusable presets, and provides:
- **CNCC ControlNet**: runs a saved preprocessor preset on its own.
- **CNCC Apply ControlNet**: a drop-in alternative to the native `Apply ControlNet` node — loads a ControlNet model, runs the preprocessor, and applies it to `positive`/`negative` conditioning in one node (supports chaining multiple ControlNets).

A settings modal lets users create/manage presets from a thumbnail gallery. UI is available in Japanese/English/Simplified Chinese, following ComfyUI's `Comfy.Locale` setting.

Released under Apache License 2.0; see the repo README for licensing notes on `comfyui_controlnet_aux` and ComfyUI itself.

## Test plan

- [x] Validated `custom-node-list.json` as valid JSON after the change
- [x] Confirmed no duplicate/conflicting entry for this node already exists in the list
- [x] Repo has a tagged GitHub Release (`v0.1.0`)